### PR TITLE
Mark constructors with `InternalKotlinCryptoApi` annotation

### DIFF
--- a/library/digest/api/digest.api
+++ b/library/digest/api/digest.api
@@ -1,6 +1,4 @@
 public abstract class org/kotlincrypto/core/Digest : java/security/MessageDigest, java/lang/Cloneable, org/kotlincrypto/core/Algorithm, org/kotlincrypto/core/Copyable, org/kotlincrypto/core/Resettable, org/kotlincrypto/core/Updatable {
-	protected fun <init> (Ljava/lang/String;II)V
-	protected fun <init> (Lorg/kotlincrypto/core/internal/DigestState;)V
 	public final fun algorithm ()Ljava/lang/String;
 	public final fun blockSize ()I
 	public final fun clone ()Ljava/lang/Object;

--- a/library/digest/src/commonMain/kotlin/org/kotlincrypto/core/Digest.kt
+++ b/library/digest/src/commonMain/kotlin/org/kotlincrypto/core/Digest.kt
@@ -48,6 +48,7 @@ public expect abstract class Digest private constructor(
      *  - [blockSize] is not a factor of 8
      *  - [digestLength] is less than or equal to 0
      * */
+    @InternalKotlinCryptoApi
     @Throws(IllegalArgumentException::class)
     protected constructor(algorithm: String, blockSize: Int, digestLength: Int)
 
@@ -83,6 +84,7 @@ public expect abstract class Digest private constructor(
      *
      * @see [DigestState]
      * */
+    @InternalKotlinCryptoApi
     protected constructor(state: DigestState)
 
     public final override fun algorithm(): String

--- a/library/digest/src/commonTest/kotlin/org/kotlincrypto/core/TestDigest.kt
+++ b/library/digest/src/commonTest/kotlin/org/kotlincrypto/core/TestDigest.kt
@@ -17,6 +17,8 @@ package org.kotlincrypto.core
 
 import org.kotlincrypto.core.internal.DigestState
 
+@Suppress("UnnecessaryOptInAnnotation")
+@OptIn(InternalKotlinCryptoApi::class)
 class TestDigest: Digest {
 
     private val compress: (buffer: ByteArray) -> Unit

--- a/library/digest/src/jvmMain/kotlin/org/kotlincrypto/core/Digest.kt
+++ b/library/digest/src/jvmMain/kotlin/org/kotlincrypto/core/Digest.kt
@@ -62,6 +62,7 @@ public actual abstract class Digest private actual constructor(
      *  - [blockSize] is not a factor of 8
      *  - [digestLength] is less than or equal to 0
      * */
+    @InternalKotlinCryptoApi
     @Throws(IllegalArgumentException::class)
     protected actual constructor(
         algorithm: String,
@@ -106,6 +107,7 @@ public actual abstract class Digest private actual constructor(
      *
      * @see [DigestState]
      * */
+    @InternalKotlinCryptoApi
     protected actual constructor(
         state: DigestState
     ): this(

--- a/library/digest/src/nonJvmMain/kotlin/org/kotlincrypto/core/Digest.kt
+++ b/library/digest/src/nonJvmMain/kotlin/org/kotlincrypto/core/Digest.kt
@@ -56,6 +56,7 @@ public actual abstract class Digest private actual constructor(
      *  - [blockSize] is not a factor of 8
      *  - [digestLength] is less than or equal to 0
      * */
+    @InternalKotlinCryptoApi
     @Throws(IllegalArgumentException::class)
     protected actual constructor(
         algorithm: String,
@@ -100,6 +101,7 @@ public actual abstract class Digest private actual constructor(
      *
      * @see [DigestState]
      * */
+    @InternalKotlinCryptoApi
     protected actual constructor(
         state: DigestState
     ): this(

--- a/library/mac/api/mac.api
+++ b/library/mac/api/mac.api
@@ -1,5 +1,4 @@
 public abstract class org/kotlincrypto/core/Mac : javax/crypto/Mac, org/kotlincrypto/core/Algorithm, org/kotlincrypto/core/Copyable, org/kotlincrypto/core/Resettable, org/kotlincrypto/core/Updatable {
-	protected fun <init> (Ljava/lang/String;Lorg/kotlincrypto/core/Mac$Engine;)V
 	public final fun algorithm ()Ljava/lang/String;
 	public synthetic fun copy ()Ljava/lang/Object;
 	public final fun copy ()Lorg/kotlincrypto/core/Mac;
@@ -11,8 +10,6 @@ public abstract class org/kotlincrypto/core/Mac : javax/crypto/Mac, org/kotlincr
 }
 
 protected abstract class org/kotlincrypto/core/Mac$Engine : javax/crypto/MacSpi, java/lang/Cloneable, org/kotlincrypto/core/Copyable, org/kotlincrypto/core/Resettable, org/kotlincrypto/core/Updatable {
-	protected fun <init> (Lorg/kotlincrypto/core/Mac$Engine$State;)V
-	public fun <init> ([B)V
 	public final fun clone ()Ljava/lang/Object;
 	public abstract fun doFinal ()[B
 	protected final fun engineDoFinal ()[B

--- a/library/mac/src/commonMain/kotlin/org/kotlincrypto/core/Mac.kt
+++ b/library/mac/src/commonMain/kotlin/org/kotlincrypto/core/Mac.kt
@@ -33,6 +33,7 @@ package org.kotlincrypto.core
  * @throws [IllegalArgumentException] if [algorithm] is blank
  * */
 public expect abstract class Mac
+@InternalKotlinCryptoApi
 @Throws(IllegalArgumentException::class)
 protected constructor(
     algorithm: String,
@@ -127,12 +128,14 @@ protected constructor(
          *
          * @throws [IllegalArgumentException] if [key] is empty.
          * */
+        @InternalKotlinCryptoApi
         @Throws(IllegalArgumentException::class)
         public constructor(key: ByteArray)
 
         /**
          * Creates a new [Engine] for the copied [State]
          * */
+        @InternalKotlinCryptoApi
         protected constructor(state: State)
 
         public abstract fun macLength(): Int

--- a/library/mac/src/commonTest/kotlin/org/kotlincrypto/core/MacUnitTest.kt
+++ b/library/mac/src/commonTest/kotlin/org/kotlincrypto/core/MacUnitTest.kt
@@ -21,6 +21,8 @@ import kotlin.test.fail
 
 class MacUnitTest {
 
+    @Suppress("UnnecessaryOptInAnnotation")
+    @OptIn(InternalKotlinCryptoApi::class)
     private class TestMac : Mac {
 
         constructor(key: ByteArray, algorithm: String): super(algorithm, TestEngine(key))

--- a/library/mac/src/jvmMain/kotlin/org/kotlincrypto/core/Mac.kt
+++ b/library/mac/src/jvmMain/kotlin/org/kotlincrypto/core/Mac.kt
@@ -41,6 +41,7 @@ import javax.crypto.MacSpi
  * @throws [IllegalArgumentException] if [algorithm] is blank
  * */
 public actual abstract class Mac
+@InternalKotlinCryptoApi
 @Throws(IllegalArgumentException::class)
 protected actual constructor(
     algorithm: String,
@@ -136,12 +137,14 @@ protected actual constructor(
          *
          * @throws [IllegalArgumentException] if [key] is empty.
          * */
+        @InternalKotlinCryptoApi
         @Throws(IllegalArgumentException::class)
         public actual constructor(key: ByteArray): super() { require(key.isNotEmpty()) { "key cannot be empty" } }
 
         /**
          * Creates a new [Engine] for the copied [State]
          * */
+        @InternalKotlinCryptoApi
         protected actual constructor(state: State): super()
 
         public actual abstract fun macLength(): Int

--- a/library/mac/src/nonJvmMain/kotlin/org/kotlincrypto/core/Mac.kt
+++ b/library/mac/src/nonJvmMain/kotlin/org/kotlincrypto/core/Mac.kt
@@ -36,6 +36,7 @@ import org.kotlincrypto.core.internal.commonToString
  * @throws [IllegalArgumentException] if [algorithm] is blank
  * */
 public actual abstract class Mac
+@InternalKotlinCryptoApi
 @Throws(IllegalArgumentException::class)
 protected actual constructor(
     private val algorithm: String,
@@ -135,12 +136,14 @@ protected actual constructor(
          *
          * @throws [IllegalArgumentException] if [key] is empty.
          * */
+        @InternalKotlinCryptoApi
         @Throws(IllegalArgumentException::class)
         public actual constructor(key: ByteArray) { require(key.isNotEmpty()) { "key cannot be empty" } }
 
         /**
          * Creates a new [Engine] for the copied [State]
          * */
+        @InternalKotlinCryptoApi
         protected actual constructor(state: State)
 
         public actual abstract fun macLength(): Int


### PR DESCRIPTION
Closes #8 