### PR TITLE
Modify `Digest.compress` API to add an offset

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,13 @@
 
 Low level core cryptographic components for Kotlin Multiplatform
 
+This library has very low level APIs that are used in higher level 
+implementations. You most likely never will need to add this as a
+dependency.
+
 If you are looking for Hashing algorithms (e.g. `SHA-256`, `SHA-512`, etc), see the [hash repo][url-hash].
+
+If you are looking for Mac algorithms (e.g. `HmacSHA256`, `HmacSHA512`, etc), see the [MACs repo][url-macs].
 
 ### Get Started
 
@@ -78,3 +84,4 @@ dependencies {
 [url-license]: https://www.apache.org/licenses/LICENSE-2.0.txt
 [url-kotlin]: https://kotlinlang.org
 [url-hash]: https://github.com/KotlinCrypto/hash
+[url-macs]: https://github.com/KotlinCrypto/MACs

--- a/library/digest/api/digest.api
+++ b/library/digest/api/digest.api
@@ -2,7 +2,7 @@ public abstract class org/kotlincrypto/core/Digest : java/security/MessageDigest
 	public final fun algorithm ()Ljava/lang/String;
 	public final fun blockSize ()I
 	public final fun clone ()Ljava/lang/Object;
-	protected abstract fun compress ([B)V
+	protected abstract fun compress ([BI)V
 	public synthetic fun copy ()Ljava/lang/Object;
 	public final fun copy ()Lorg/kotlincrypto/core/Digest;
 	protected abstract fun copy (Lorg/kotlincrypto/core/internal/DigestState;)Lorg/kotlincrypto/core/Digest;

--- a/library/digest/src/commonMain/kotlin/org/kotlincrypto/core/Digest.kt
+++ b/library/digest/src/commonMain/kotlin/org/kotlincrypto/core/Digest.kt
@@ -111,7 +111,11 @@ public expect abstract class Digest private constructor(
     public final override fun copy(): Digest
     protected abstract fun copy(state: DigestState): Digest
 
-    protected abstract fun compress(buffer: ByteArray)
+    /**
+     * Called whenever a full [blockSize] worth of bytes is available
+     * to be processed, starting at index [offset] for the [input].
+     * */
+    protected abstract fun compress(input: ByteArray, offset: Int)
     protected abstract fun digest(bitLength: Long, bufferOffset: Int, buffer: ByteArray): ByteArray
     protected abstract fun resetDigest()
 }

--- a/library/digest/src/commonMain/kotlin/org/kotlincrypto/core/internal/DigestDelegate.kt
+++ b/library/digest/src/commonMain/kotlin/org/kotlincrypto/core/internal/DigestDelegate.kt
@@ -27,7 +27,7 @@ internal class DigestDelegate private constructor(
     private val buffer: ByteArray,
     private var bufferOffs: Int,
     private var compressCount: Long,
-    private val compress: (buffer: ByteArray) -> Unit,
+    private val compress: (input: ByteArray, offset: Int) -> Unit,
     private val digest: (bitLength: Long, bufferOffset: Int, buffer: ByteArray) -> ByteArray,
     private val resetDigest: () -> Unit
 ): Copyable<DigestState>, Resettable, Updatable {
@@ -36,7 +36,7 @@ internal class DigestDelegate private constructor(
         buffer[bufferOffs] = input
 
         if (++bufferOffs != blockSize) return
-        compress(buffer)
+        compress(buffer, 0)
         ++compressCount
         bufferOffs = 0
     }
@@ -62,8 +62,7 @@ internal class DigestDelegate private constructor(
 
         // chunk
         while (remaining >= blockSize) {
-            input.copyInto(buffer, 0, i, i + blockSize)
-            compress(buffer)
+            compress(input, i)
             i += blockSize
             remaining -= blockSize
             ++compressCount
@@ -102,7 +101,7 @@ internal class DigestDelegate private constructor(
         @JvmSynthetic
         internal fun instance(
             state: DigestState,
-            compress: (buffer: ByteArray) -> Unit,
+            compress: (input: ByteArray, offset: Int) -> Unit,
             digest: (bitLength: Long, bufferOffset: Int, buffer: ByteArray) -> ByteArray,
             resetDigest: () -> Unit
         ): DigestDelegate {
@@ -125,7 +124,7 @@ internal class DigestDelegate private constructor(
             algorithm: String,
             blockSize: Int,
             digestLength: Int,
-            compress: (buffer: ByteArray) -> Unit,
+            compress: (input: ByteArray, offset: Int) -> Unit,
             digest: (bitLength: Long, bufferOffset: Int, buffer: ByteArray) -> ByteArray,
             resetDigest: () -> Unit
         ): DigestDelegate {

--- a/library/digest/src/commonTest/kotlin/org/kotlincrypto/core/DigestUnitTest.kt
+++ b/library/digest/src/commonTest/kotlin/org/kotlincrypto/core/DigestUnitTest.kt
@@ -56,7 +56,7 @@ class DigestUnitTest: TestDigestException() {
         var compressCount = 0
 
         val digest = TestDigest(
-            compress = { compressCount++ },
+            compress = { _, _ -> compressCount++ },
             // Return byte array sized to the offset
             digest = { _, offset, _ -> ByteArray(offset) }
         )

--- a/library/digest/src/commonTest/kotlin/org/kotlincrypto/core/TestDigest.kt
+++ b/library/digest/src/commonTest/kotlin/org/kotlincrypto/core/TestDigest.kt
@@ -21,7 +21,7 @@ import org.kotlincrypto.core.internal.DigestState
 @OptIn(InternalKotlinCryptoApi::class)
 class TestDigest: Digest {
 
-    private val compress: (buffer: ByteArray) -> Unit
+    private val compress: (input: ByteArray, offset: Int) -> Unit
     private val finalize: (Long, Int, ByteArray) -> ByteArray
     private val reset: () -> Unit
 
@@ -31,7 +31,7 @@ class TestDigest: Digest {
         algorithm: String = "TEST",
         blockSize: Int = 64,
         digestLength: Int = 32,
-        compress: (buffer: ByteArray) -> Unit = {},
+        compress: (input: ByteArray, offset: Int) -> Unit = { _, _ -> },
         digest: (bitLength: Long, bufferOffset: Int, buffer: ByteArray) -> ByteArray = { _, _, _ -> ByteArray(blockSize) },
         reset: () -> Unit = {},
     ): super(algorithm, blockSize, digestLength) {
@@ -42,7 +42,7 @@ class TestDigest: Digest {
 
     private constructor(
         state: DigestState,
-        compress: (buffer: ByteArray) -> Unit,
+        compress: (input: ByteArray, offset: Int) -> Unit,
         digest: (bitLength: Long, bufferOffset: Int, buffer: ByteArray) -> ByteArray,
         reset: () -> Unit,
     ): super(state) {
@@ -51,8 +51,8 @@ class TestDigest: Digest {
         this.reset = reset
     }
 
-    override fun compress(buffer: ByteArray) {
-        compress.invoke(buffer)
+    override fun compress(input: ByteArray, offset: Int) {
+        compress.invoke(input, offset)
     }
 
     override fun digest(bitLength: Long, bufferOffset: Int, buffer: ByteArray): ByteArray {

--- a/library/digest/src/jvmMain/kotlin/org/kotlincrypto/core/Digest.kt
+++ b/library/digest/src/jvmMain/kotlin/org/kotlincrypto/core/Digest.kt
@@ -157,7 +157,11 @@ public actual abstract class Digest private actual constructor(
     public actual final override fun copy(): Digest = copy(delegate.copy())
     protected actual abstract fun copy(state: DigestState): Digest
 
-    protected actual abstract fun compress(buffer: ByteArray)
+    /**
+     * Called whenever a full [blockSize] worth of bytes is available
+     * to be processed, starting at index [offset] for the [input].
+     * */
+    protected actual abstract fun compress(input: ByteArray, offset: Int)
     protected actual abstract fun digest(bitLength: Long, bufferOffset: Int, buffer: ByteArray): ByteArray
     protected actual abstract fun resetDigest()
 }

--- a/library/digest/src/jvmTest/kotlin/org/kotlincrypto/core/JvmDigestUnitTest.kt
+++ b/library/digest/src/jvmTest/kotlin/org/kotlincrypto/core/JvmDigestUnitTest.kt
@@ -42,8 +42,8 @@ class JvmDigestUnitTest {
 
         override fun copy(state: DigestState): Digest = MessageDigestWrap(state, this)
 
-        override fun compress(buffer: ByteArray) {
-            delegate.update(buffer)
+        override fun compress(input: ByteArray, offset: Int) {
+            delegate.update(input, offset, blockSize())
         }
 
         override fun digest(bitLength: Long, bufferOffset: Int, buffer: ByteArray): ByteArray {

--- a/library/digest/src/nonJvmMain/kotlin/org/kotlincrypto/core/Digest.kt
+++ b/library/digest/src/nonJvmMain/kotlin/org/kotlincrypto/core/Digest.kt
@@ -135,7 +135,11 @@ public actual abstract class Digest private actual constructor(
     public actual final override fun copy(): Digest = copy(delegate.copy())
     protected actual abstract fun copy(state: DigestState): Digest
 
-    protected actual abstract fun compress(buffer: ByteArray)
+    /**
+     * Called whenever a full [blockSize] worth of bytes is available
+     * to be processed, starting at index [offset] for the [input].
+     * */
+    protected actual abstract fun compress(input: ByteArray, offset: Int)
     protected actual abstract fun digest(bitLength: Long, bufferOffset: Int, buffer: ByteArray): ByteArray
     protected actual abstract fun resetDigest()
 }


### PR DESCRIPTION
Closes #20 

This PR modifies the `Digest.compress` function such that it now includes an offset.

**THIS IS AN API BREAKING CHANGE**, but **only** for implementors of `Digest` (i.e. `KotlinCrypto/hash`).

By including an `offset: Int`, this drastically increases performance as `Digest` no longer needs to array copy `input` into the buffer.

Will require a `0.2.0` release, as well as a version bump of `hash` and `MACs` repository.

A `0.2.0-SNAPSHOT` is available from MavenCentral. The snapshot was also tested in the `KotlinCrypto/hash` repository with the API modification. Everything worked as expected.