### PR TITLE
Add `Digest.updateDigest` open functions to override

### DIFF
--- a/library/digest/api/digest.api
+++ b/library/digest/api/digest.api
@@ -23,10 +23,11 @@ public abstract class org/kotlincrypto/core/Digest : java/security/MessageDigest
 	public final fun reset ()V
 	protected abstract fun resetDigest ()V
 	public final fun toString ()Ljava/lang/String;
-	public fun update (B)V
-	protected fun update (II[B)V
+	public final fun update (B)V
 	public final fun update ([B)V
 	public final fun update ([BII)V
+	protected fun updateDigest (B)V
+	protected fun updateDigest ([BII)V
 }
 
 public abstract class org/kotlincrypto/core/internal/DigestState {

--- a/library/digest/api/digest.api
+++ b/library/digest/api/digest.api
@@ -23,7 +23,8 @@ public abstract class org/kotlincrypto/core/Digest : java/security/MessageDigest
 	public final fun reset ()V
 	protected abstract fun resetDigest ()V
 	public final fun toString ()Ljava/lang/String;
-	public final fun update (B)V
+	public fun update (B)V
+	protected fun update (II[B)V
 	public final fun update ([B)V
 	public final fun update ([BII)V
 }

--- a/library/digest/src/commonMain/kotlin/org/kotlincrypto/core/Digest.kt
+++ b/library/digest/src/commonMain/kotlin/org/kotlincrypto/core/Digest.kt
@@ -59,32 +59,6 @@ public expect abstract class Digest private constructor(
      * Implementors of [Digest] should have a private secondary constructor
      * that is utilized by its [copy] implementation.
      *
-     * e.g.
-     *
-     *     class Md5: Digest {
-     *
-     *         private val x: IntArray
-     *         private val state: IntArray
-     *
-     *         constructor(): super("MD5", 64, 16) {
-     *             x =  = IntArray(16)
-     *             state = intArrayOf(
-     *                 1732584193,
-     *                 -271733879,
-     *                 -1732584194,
-     *                 271733878,
-     *             )
-     *         }
-     *         private constructor(state: DigestState, md5: Md5): super(state) {
-     *             x = md5.x.copyOf()
-     *             this.state = md5.state.copyOf()
-     *         }
-     *
-     *         protected override fun copy(state: DigestState): Md5 = Md5(state, this)
-     *
-     *         // ...
-     *     }
-     *
      * @see [DigestState]
      * */
     @InternalKotlinCryptoApi
@@ -94,10 +68,13 @@ public expect abstract class Digest private constructor(
     public fun blockSize(): Int
     public fun digestLength(): Int
 
-    public final override fun update(input: Byte)
     public final override fun update(input: ByteArray)
     @Throws(IllegalArgumentException::class, IndexOutOfBoundsException::class)
     public final override fun update(input: ByteArray, offset: Int, len: Int)
+
+    public override fun update(input: Byte)
+    // Input arguments are always checked for validity before this is called
+    protected open fun update(offset: Int, len: Int, input: ByteArray)
 
     public fun digest(): ByteArray
     public fun digest(input: ByteArray): ByteArray

--- a/library/digest/src/commonMain/kotlin/org/kotlincrypto/core/Digest.kt
+++ b/library/digest/src/commonMain/kotlin/org/kotlincrypto/core/Digest.kt
@@ -68,13 +68,10 @@ public expect abstract class Digest private constructor(
     public fun blockSize(): Int
     public fun digestLength(): Int
 
+    public final override fun update(input: Byte)
     public final override fun update(input: ByteArray)
     @Throws(IllegalArgumentException::class, IndexOutOfBoundsException::class)
     public final override fun update(input: ByteArray, offset: Int, len: Int)
-
-    public override fun update(input: Byte)
-    // Input arguments are always checked for validity before this is called
-    protected open fun update(offset: Int, len: Int, input: ByteArray)
 
     public fun digest(): ByteArray
     public fun digest(input: ByteArray): ByteArray
@@ -95,4 +92,18 @@ public expect abstract class Digest private constructor(
     protected abstract fun compress(input: ByteArray, offset: Int)
     protected abstract fun digest(bitLength: Long, bufferOffset: Int, buffer: ByteArray): ByteArray
     protected abstract fun resetDigest()
+
+    /**
+     * Protected, direct access to the [Digest]'s buffer. All external input
+     * is directed here such that implementations can override and intercept
+     * if necessary.
+     * */
+    protected open fun updateDigest(input: Byte)
+
+    /**
+     * Protected, direct access to the [Digest]'s buffer. All external input
+     * is validated before being directed here such that implementations can
+     * override and intercept if necessary.
+     * */
+    protected open fun updateDigest(input: ByteArray, offset: Int, len: Int)
 }

--- a/library/digest/src/commonMain/kotlin/org/kotlincrypto/core/internal/-DigestCommon.kt
+++ b/library/digest/src/commonMain/kotlin/org/kotlincrypto/core/internal/-DigestCommon.kt
@@ -18,26 +18,15 @@
 package org.kotlincrypto.core.internal
 
 import org.kotlincrypto.core.Digest
-import kotlin.contracts.ExperimentalContracts
-import kotlin.contracts.InvocationKind
-import kotlin.contracts.contract
 
 @Suppress("NOTHING_TO_INLINE")
 internal inline fun Digest.commonToString(): String {
     return "Digest[${algorithm()}]@${hashCode()}"
 }
 
-@OptIn(ExperimentalContracts::class)
 @Suppress("NOTHING_TO_INLINE")
 @Throws(IllegalArgumentException::class, IndexOutOfBoundsException::class)
-internal inline fun ByteArray.commonIfArgumentsValid(offset: Int, len: Int, block: () -> Unit) {
-    contract {
-        callsInPlace(block, InvocationKind.AT_MOST_ONCE)
-    }
-
+internal inline fun ByteArray.commonCheckArgs(offset: Int, len: Int) {
     if (size - offset < len) throw IllegalArgumentException("Input too short")
-    if (len == 0) return
     if (offset < 0 || len < 0 || offset > size - len) throw IndexOutOfBoundsException()
-
-    block()
 }

--- a/library/digest/src/commonMain/kotlin/org/kotlincrypto/core/internal/-DigestCommon.kt
+++ b/library/digest/src/commonMain/kotlin/org/kotlincrypto/core/internal/-DigestCommon.kt
@@ -18,8 +18,26 @@
 package org.kotlincrypto.core.internal
 
 import org.kotlincrypto.core.Digest
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 
 @Suppress("NOTHING_TO_INLINE")
 internal inline fun Digest.commonToString(): String {
     return "Digest[${algorithm()}]@${hashCode()}"
+}
+
+@OptIn(ExperimentalContracts::class)
+@Suppress("NOTHING_TO_INLINE")
+@Throws(IllegalArgumentException::class, IndexOutOfBoundsException::class)
+internal inline fun ByteArray.commonIfArgumentsValid(offset: Int, len: Int, block: () -> Unit) {
+    contract {
+        callsInPlace(block, InvocationKind.AT_MOST_ONCE)
+    }
+
+    if (size - offset < len) throw IllegalArgumentException("Input too short")
+    if (len == 0) return
+    if (offset < 0 || len < 0 || offset > size - len) throw IndexOutOfBoundsException()
+
+    block()
 }

--- a/library/digest/src/commonMain/kotlin/org/kotlincrypto/core/internal/DigestDelegate.kt
+++ b/library/digest/src/commonMain/kotlin/org/kotlincrypto/core/internal/DigestDelegate.kt
@@ -30,9 +30,9 @@ internal class DigestDelegate private constructor(
     private val compress: (input: ByteArray, offset: Int) -> Unit,
     private val digest: (bitLength: Long, bufferOffset: Int, buffer: ByteArray) -> ByteArray,
     private val resetDigest: () -> Unit
-): Copyable<DigestState>, Resettable, Updatable {
+): Copyable<DigestState>, Resettable {
 
-    override fun update(input: Byte) {
+    internal fun update(input: Byte) {
         buffer[bufferOffs] = input
 
         if (++bufferOffs != blockSize) return
@@ -41,16 +41,7 @@ internal class DigestDelegate private constructor(
         bufferOffs = 0
     }
 
-    override fun update(input: ByteArray) {
-        update(input, 0, input.size)
-    }
-
-    @Throws(IllegalArgumentException::class, IndexOutOfBoundsException::class)
-    override fun update(input: ByteArray, offset: Int, len: Int) {
-        if (input.size - offset < len) throw IllegalArgumentException("Input too short")
-        if (len == 0) return
-        if (offset < 0 || len < 0 || offset > input.size - len) throw IndexOutOfBoundsException()
-
+    internal fun update(input: ByteArray, offset: Int, len: Int) {
         var i = offset
         var remaining = len
 

--- a/library/digest/src/commonMain/kotlin/org/kotlincrypto/core/internal/DigestDelegate.kt
+++ b/library/digest/src/commonMain/kotlin/org/kotlincrypto/core/internal/DigestDelegate.kt
@@ -17,7 +17,6 @@ package org.kotlincrypto.core.internal
 
 import org.kotlincrypto.core.Copyable
 import org.kotlincrypto.core.Resettable
-import org.kotlincrypto.core.Updatable
 import kotlin.jvm.JvmSynthetic
 
 internal class DigestDelegate private constructor(

--- a/library/digest/src/commonTest/kotlin/org/kotlincrypto/core/TestDigestException.kt
+++ b/library/digest/src/commonTest/kotlin/org/kotlincrypto/core/TestDigestException.kt
@@ -31,27 +31,6 @@ abstract class TestDigestException: Updatable {
     }
 
     @Test
-    fun givenDigest_whenLength0_thenThrowsExpected() {
-        // Input length check will pass here, but
-        // this would produce an ArrayIndexOutOfBounds exception
-        // unless len is 0
-        update(ByteArray(0), -1, 0)
-
-        // This ensures that both jvm and non-Jvm check
-        // input length _before_ length == 0 which will
-        // simply return and not produce an error.
-        //
-        // If len > 0, this would throw an ArrayIndexOutOfBounds
-        // exception because offset > input.size
-        try {
-            update(ByteArray(0), 1, 0)
-            fail()
-        } catch (_: IllegalArgumentException) {
-            // pass
-        }
-    }
-
-    @Test
     fun givenDigest_whenLengthNegative_thenThrows() {
         try {
             update(ByteArray(0), 0, -1)

--- a/library/digest/src/jvmMain/kotlin/org/kotlincrypto/core/Digest.kt
+++ b/library/digest/src/jvmMain/kotlin/org/kotlincrypto/core/Digest.kt
@@ -17,7 +17,7 @@ package org.kotlincrypto.core
 
 import org.kotlincrypto.core.internal.DigestDelegate
 import org.kotlincrypto.core.internal.DigestState
-import org.kotlincrypto.core.internal.commonIfArgumentsValid
+import org.kotlincrypto.core.internal.commonCheckArgs
 import org.kotlincrypto.core.internal.commonToString
 import java.nio.ByteBuffer
 import java.security.DigestException
@@ -95,9 +95,8 @@ public actual abstract class Digest private actual constructor(
     }
     @Throws(IllegalArgumentException::class, IndexOutOfBoundsException::class)
     public actual final override fun update(input: ByteArray, offset: Int, len: Int) {
-        input.commonIfArgumentsValid(offset, len) {
-            updateDigest(input, offset, len)
-        }
+        input.commonCheckArgs(offset, len)
+        updateDigest(input, offset, len)
     }
 
     public actual final override fun digest(): ByteArray = delegate.digest()

--- a/library/digest/src/jvmMain/kotlin/org/kotlincrypto/core/Digest.kt
+++ b/library/digest/src/jvmMain/kotlin/org/kotlincrypto/core/Digest.kt
@@ -17,6 +17,7 @@ package org.kotlincrypto.core
 
 import org.kotlincrypto.core.internal.DigestDelegate
 import org.kotlincrypto.core.internal.DigestState
+import org.kotlincrypto.core.internal.commonIfArgumentsValid
 import org.kotlincrypto.core.internal.commonToString
 import java.nio.ByteBuffer
 import java.security.DigestException
@@ -68,12 +69,7 @@ public actual abstract class Digest private actual constructor(
         algorithm: String,
         blockSize: Int,
         digestLength: Int
-    ): this(
-        algorithm = algorithm,
-        blockSize = blockSize,
-        digestLength = digestLength,
-        state = null
-    )
+    ): this(algorithm, blockSize, digestLength, null)
 
     /**
      * Creates a new [Digest] for the copied [state] of another [Digest]
@@ -82,72 +78,44 @@ public actual abstract class Digest private actual constructor(
      * Implementors of [Digest] should have a private secondary constructor
      * that is utilized by its [copy] implementation.
      *
-     * e.g.
-     *
-     *     class Md5: Digest {
-     *
-     *         private val x: IntArray
-     *         private val state: IntArray
-     *
-     *         constructor(): super("MD5", 64, 16) {
-     *             x =  = IntArray(16)
-     *             state = intArrayOf(
-     *                 1732584193,
-     *                 -271733879,
-     *                 -1732584194,
-     *                 271733878,
-     *             )
-     *         }
-     *         private constructor(state: DigestState, md5: Md5): super(state) {
-     *             x = md5.x.copyOf()
-     *             this.state = md5.state.copyOf()
-     *         }
-     *
-     *         protected override fun copy(state: DigestState): Md5 = Md5(state, this)
-     *
-     *         // ...
-     *     }
-     *
      * @see [DigestState]
      * */
     @InternalKotlinCryptoApi
     protected actual constructor(
         state: DigestState
-    ): this(
-        algorithm = state.algorithm,
-        blockSize = state.blockSize,
-        digestLength = state.digestLength,
-        state = state
-    )
+    ): this(state.algorithm, state.blockSize, state.digestLength, state)
 
     public actual final override fun algorithm(): String = delegate.algorithm
     public actual fun blockSize(): Int = delegate.blockSize
     public actual fun digestLength(): Int = delegate.digestLength
 
-    public actual final override fun update(input: Byte) { delegate.update(input) }
-    public actual final override fun update(input: ByteArray) { delegate.update(input) }
+    public actual final override fun update(input: ByteArray) {
+        update(0, input.size, input)
+    }
     @Throws(IllegalArgumentException::class, IndexOutOfBoundsException::class)
-    public actual final override fun update(input: ByteArray, offset: Int, len: Int) { delegate.update(input, offset, len) }
+    public actual final override fun update(input: ByteArray, offset: Int, len: Int) {
+        input.commonIfArgumentsValid(offset, len) {
+            update(offset, len, input)
+        }
+    }
+
+    public actual override fun update(input: Byte) {
+        delegate.update(input)
+    }
+    // Input arguments are always checked for validity before this is called
+    protected actual open fun update(offset: Int, len: Int, input: ByteArray) {
+        delegate.update(input, offset, len)
+    }
 
     public actual final override fun digest(): ByteArray = delegate.digest()
-    public actual final override fun digest(input: ByteArray): ByteArray { delegate.update(input); return delegate.digest() }
+    public actual final override fun digest(input: ByteArray): ByteArray {
+        update(0, input.size, input)
+        return delegate.digest()
+    }
     @Throws(IllegalArgumentException::class, DigestException::class)
     public final override fun digest(buf: ByteArray, offset: Int, len: Int): Int = super.digest(buf, offset, len)
 
     public actual final override fun reset() { delegate.reset() }
-
-    protected final override fun engineGetDigestLength(): Int = delegate.digestLength
-
-    protected final override fun engineUpdate(p0: Byte) { delegate.update(p0) }
-    protected final override fun engineUpdate(input: ByteBuffer) { super.engineUpdate(input) }
-    @Throws(IllegalArgumentException::class, IndexOutOfBoundsException::class)
-    protected final override fun engineUpdate(p0: ByteArray, p1: Int, p2: Int) { delegate.update(p0, p1, p2) }
-
-    protected final override fun engineDigest(): ByteArray = delegate.digest()
-    @Throws(DigestException::class)
-    protected final override fun engineDigest(buf: ByteArray, offset: Int, len: Int): Int = super.engineDigest(buf, offset, len)
-
-    protected final override fun engineReset() { delegate.reset() }
 
     public actual final override fun equals(other: Any?): Boolean = other is Digest && other.delegate == delegate
     public actual final override fun hashCode(): Int = delegate.hashCode()
@@ -164,4 +132,17 @@ public actual abstract class Digest private actual constructor(
     protected actual abstract fun compress(input: ByteArray, offset: Int)
     protected actual abstract fun digest(bitLength: Long, bufferOffset: Int, buffer: ByteArray): ByteArray
     protected actual abstract fun resetDigest()
+
+    // MessageDigestSpi
+    protected final override fun engineGetDigestLength(): Int = delegate.digestLength
+    protected final override fun engineUpdate(p0: Byte) { update(p0) }
+    protected final override fun engineUpdate(input: ByteBuffer) { super.engineUpdate(input) }
+    @Throws(IllegalArgumentException::class, IndexOutOfBoundsException::class)
+    protected final override fun engineUpdate(p0: ByteArray, p1: Int, p2: Int) { update(p0, p1, p2) }
+    protected final override fun engineDigest(): ByteArray = delegate.digest()
+    @Throws(DigestException::class)
+    protected final override fun engineDigest(buf: ByteArray, offset: Int, len: Int): Int {
+        return super.engineDigest(buf, offset, len)
+    }
+    protected final override fun engineReset() { delegate.reset() }
 }

--- a/library/digest/src/nonJvmMain/kotlin/org/kotlincrypto/core/Digest.kt
+++ b/library/digest/src/nonJvmMain/kotlin/org/kotlincrypto/core/Digest.kt
@@ -17,7 +17,7 @@ package org.kotlincrypto.core
 
 import org.kotlincrypto.core.internal.DigestDelegate
 import org.kotlincrypto.core.internal.DigestState
-import org.kotlincrypto.core.internal.commonIfArgumentsValid
+import org.kotlincrypto.core.internal.commonCheckArgs
 import org.kotlincrypto.core.internal.commonToString
 
 /**
@@ -89,9 +89,8 @@ public actual abstract class Digest private actual constructor(
     }
     @Throws(IllegalArgumentException::class, IndexOutOfBoundsException::class)
     public actual final override fun update(input: ByteArray, offset: Int, len: Int) {
-        input.commonIfArgumentsValid(offset, len) {
-            updateDigest(input, offset, len)
-        }
+        input.commonCheckArgs(offset, len)
+        updateDigest(input, offset, len)
     }
 
     public actual fun digest(): ByteArray = delegate.digest()


### PR DESCRIPTION
This PR adds `protected open function updateDigest` methods which implementations can choose to override in order to intercept input before it is added to the delegate's buffer. All external input arguments from `update` are checked prior to directing to `updateDigest`.