### PR TITLE
Allow `digestLength` of 0

### DIFF
--- a/library/digest/src/commonMain/kotlin/org/kotlincrypto/core/Digest.kt
+++ b/library/digest/src/commonMain/kotlin/org/kotlincrypto/core/Digest.kt
@@ -46,7 +46,7 @@ public expect abstract class Digest private constructor(
      *  - [algorithm] is blank
      *  - [blockSize] is less than or equal to 0
      *  - [blockSize] is not a factor of 8
-     *  - [digestLength] is less than or equal to 0
+     *  - [digestLength] is less than 0
      * */
     @InternalKotlinCryptoApi
     @Throws(IllegalArgumentException::class)

--- a/library/digest/src/commonMain/kotlin/org/kotlincrypto/core/internal/DigestDelegate.kt
+++ b/library/digest/src/commonMain/kotlin/org/kotlincrypto/core/internal/DigestDelegate.kt
@@ -122,7 +122,7 @@ internal class DigestDelegate private constructor(
             require(algorithm.isNotBlank()) { "algorithm cannot be blank" }
             require(blockSize > 0) { "blockSize must be greater than 0" }
             require(blockSize % 8 == 0) { "blockSize must be a factor of 8" }
-            require(digestLength > 0) { "digestLength must be greater than 0" }
+            require(digestLength >= 0) { "digestLength cannot be negative" }
 
             return DigestDelegate(
                 algorithm = algorithm,

--- a/library/digest/src/commonTest/kotlin/org/kotlincrypto/core/DigestUnitTest.kt
+++ b/library/digest/src/commonTest/kotlin/org/kotlincrypto/core/DigestUnitTest.kt
@@ -18,6 +18,7 @@ package org.kotlincrypto.core
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
+import kotlin.test.fail
 
 class DigestUnitTest: TestDigestException() {
 
@@ -33,6 +34,19 @@ class DigestUnitTest: TestDigestException() {
 
     override fun update(input: ByteArray, offset: Int, len: Int) {
         digest.update(input, offset, len)
+    }
+
+    @Test
+    fun givenDigest_whenLengthNegative_thenThrowsException() {
+        // accepts 0 length
+        TestDigest(digestLength = 0)
+
+        try {
+            TestDigest(digestLength = -1)
+            fail()
+        } catch (_: IllegalArgumentException) {
+            // pass
+        }
     }
 
     @Test

--- a/library/digest/src/jvmMain/kotlin/org/kotlincrypto/core/Digest.kt
+++ b/library/digest/src/jvmMain/kotlin/org/kotlincrypto/core/Digest.kt
@@ -61,7 +61,7 @@ public actual abstract class Digest private actual constructor(
      *  - [algorithm] is blank
      *  - [blockSize] is less than or equal to 0
      *  - [blockSize] is not a factor of 8
-     *  - [digestLength] is less than or equal to 0
+     *  - [digestLength] is less than 0
      * */
     @InternalKotlinCryptoApi
     @Throws(IllegalArgumentException::class)

--- a/library/digest/src/nonJvmMain/kotlin/org/kotlincrypto/core/Digest.kt
+++ b/library/digest/src/nonJvmMain/kotlin/org/kotlincrypto/core/Digest.kt
@@ -55,7 +55,7 @@ public actual abstract class Digest private actual constructor(
      *  - [algorithm] is blank
      *  - [blockSize] is less than or equal to 0
      *  - [blockSize] is not a factor of 8
-     *  - [digestLength] is less than or equal to 0
+     *  - [digestLength] is less than 0
      * */
     @InternalKotlinCryptoApi
     @Throws(IllegalArgumentException::class)


### PR DESCRIPTION
Closes #30 

This PR alters `Digest` constructor argument checks to allow passing a `digestLength` of 0. Previously, anything less than 1 would throw an `IllegalArgumentException` (because wtf is the point, right?). 0 is now an acceptable length for `digest()` output.