### PR TITLE
Throw `InvalidKeyException` if `javax.crypto.Mac.init` is invoked

### DIFF
--- a/library/mac/src/commonTest/kotlin/org/kotlincrypto/core/MacUnitTest.kt
+++ b/library/mac/src/commonTest/kotlin/org/kotlincrypto/core/MacUnitTest.kt
@@ -22,55 +22,6 @@ import kotlin.test.fail
 
 class MacUnitTest {
 
-    @Suppress("UnnecessaryOptInAnnotation")
-    @OptIn(InternalKotlinCryptoApi::class)
-    private class TestMac : Mac {
-
-        constructor(
-            key: ByteArray,
-            algorithm: String,
-            reset: () -> Unit = {},
-            doFinal: () -> ByteArray = { ByteArray(0) },
-        ): super(algorithm, TestEngine(key, reset, doFinal))
-
-        private constructor(algorithm: String, engine: TestEngine): super(algorithm, engine)
-
-        override fun copy(engineCopy: Engine): Mac = TestMac(algorithm(), engineCopy as TestEngine)
-
-        private class TestEngine: Engine {
-
-            private val reset: () -> Unit
-            private val doFinal: () -> ByteArray
-
-            constructor(
-                key: ByteArray,
-                reset: () -> Unit,
-                doFinal: () -> ByteArray,
-            ): super(key) {
-                this.reset = reset
-                this.doFinal = doFinal
-            }
-
-            private constructor(state: State, engine: TestEngine): super(state) {
-                this.reset = engine.reset
-                this.doFinal = engine.doFinal
-            }
-
-            // To ensure that Java implementation initializes javax.crypto.Mac
-            // on instantiation so that it does not throw IllegalStateException
-            // whenever updating.
-            override fun update(input: Byte) { throw ConcurrentModificationException() }
-
-            override fun reset() { reset.invoke() }
-            override fun update(input: ByteArray) {}
-            override fun update(input: ByteArray, offset: Int, len: Int) {}
-            override fun macLength(): Int = 0
-            override fun doFinal(): ByteArray = doFinal.invoke()
-
-            override fun copy(): Engine = TestEngine(object : State() {}, this)
-        }
-    }
-
     @Test
     fun givenMac_whenEmptyKey_thenThrowsException() {
         try {

--- a/library/mac/src/commonTest/kotlin/org/kotlincrypto/core/TestMac.kt
+++ b/library/mac/src/commonTest/kotlin/org/kotlincrypto/core/TestMac.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package org.kotlincrypto.core
+
+@Suppress("UnnecessaryOptInAnnotation")
+@OptIn(InternalKotlinCryptoApi::class)
+class TestMac : Mac {
+
+    constructor(
+        key: ByteArray,
+        algorithm: String,
+        reset: () -> Unit = {},
+        doFinal: () -> ByteArray = { ByteArray(0) },
+    ): super(algorithm, TestEngine(key, reset, doFinal))
+
+    private constructor(algorithm: String, engine: TestEngine): super(algorithm, engine)
+
+    override fun copy(engineCopy: Engine): Mac = TestMac(algorithm(), engineCopy as TestEngine)
+
+    private class TestEngine: Engine {
+
+        private val reset: () -> Unit
+        private val doFinal: () -> ByteArray
+
+        constructor(
+            key: ByteArray,
+            reset: () -> Unit,
+            doFinal: () -> ByteArray,
+        ): super(key) {
+            this.reset = reset
+            this.doFinal = doFinal
+        }
+
+        private constructor(state: State, engine: TestEngine): super(state) {
+            this.reset = engine.reset
+            this.doFinal = engine.doFinal
+        }
+
+        // To ensure that Java implementation initializes javax.crypto.Mac
+        // on instantiation so that it does not throw IllegalStateException
+        // whenever updating.
+        override fun update(input: Byte) { throw ConcurrentModificationException() }
+
+        override fun reset() { reset.invoke() }
+        override fun update(input: ByteArray) {}
+        override fun update(input: ByteArray, offset: Int, len: Int) {}
+        override fun macLength(): Int = 0
+        override fun doFinal(): ByteArray = doFinal.invoke()
+
+        override fun copy(): Engine = TestEngine(object : State() {}, this)
+    }
+}

--- a/library/mac/src/jvmTest/kotlin/org/kotlincrypto/core/JvmMacUnitTest.kt
+++ b/library/mac/src/jvmTest/kotlin/org/kotlincrypto/core/JvmMacUnitTest.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package org.kotlincrypto.core
+
+import java.security.InvalidKeyException
+import javax.crypto.spec.SecretKeySpec
+import kotlin.test.Test
+import kotlin.test.fail
+
+class JvmMacUnitTest {
+
+    private val key = ByteArray(20) { it.toByte() }
+
+    @Test
+    fun givenJvm_whenJavaxCryptoMacInitInvoked_thenThrowsException() {
+        val mac = TestMac(key, "My Algorithm")
+        val keySpec = SecretKeySpec(key, mac.algorithm())
+
+        try {
+            mac.init(keySpec)
+            fail()
+        } catch (_: InvalidKeyException) {
+            // pass
+        }
+
+        try {
+            mac.copy().init(keySpec)
+            fail()
+        } catch (_: InvalidKeyException) {
+            // pass
+        }
+    }
+}


### PR DESCRIPTION
Closes #42 