### PR TITLE
Add check for Android runtime to `KC_ANDROID_SDK_INT` variable

### DIFF
--- a/test-android/build.gradle.kts
+++ b/test-android/build.gradle.kts
@@ -45,14 +45,25 @@ kmpConfiguration {
                 }
             }
 
+            sourceSetTest {
+                kotlin.srcDir("src/androidUnitTest/digest")
+                kotlin.srcDir("src/androidUnitTest/mac")
+            }
+
             sourceSetTestInstrumented {
                 kotlin.srcDir("src/androidInstrumentedTest/digest")
                 kotlin.srcDir("src/androidInstrumentedTest/mac")
 
                 dependencies {
                     implementation(libs.androidx.test.runner)
-                    implementation(kotlin("test"))
+                }
+            }
+        }
 
+        common {
+            sourceSetTest {
+                dependencies {
+                    implementation(kotlin("test"))
                     implementation(project(":library:digest"))
                     implementation(project(":library:mac"))
                 }

--- a/test-android/src/androidInstrumentedTest/kotlin/org/kotlincrypto/core/AndroidSdkIntTest.kt
+++ b/test-android/src/androidInstrumentedTest/kotlin/org/kotlincrypto/core/AndroidSdkIntTest.kt
@@ -15,25 +15,14 @@
  **/
 package org.kotlincrypto.core
 
-@InternalKotlinCryptoApi
-public val KC_ANDROID_SDK_INT: Int? by lazy {
-    if (
-        System.getProperty("java.runtime.name")
-            ?.contains("android", ignoreCase = true) != true
-    ) {
-        // Not Android runtime
-        return@lazy null
-    }
+import kotlin.test.Test
+import kotlin.test.assertNotNull
 
-    try {
-        val clazz = Class.forName("android.os.Build\$VERSION")
+@OptIn(InternalKotlinCryptoApi::class)
+class AndroidSdkIntTest {
 
-        try {
-            clazz?.getField("SDK_INT")?.getInt(null)
-        } catch (_: Throwable) {
-            clazz?.getField("SDK")?.get(null)?.toString()?.toIntOrNull()
-        }
-    } catch (_: Throwable) {
-        null
+    @Test
+    fun givenAndroidSdkInt_whenAndroidRuntime_thenIsNotNull() {
+        assertNotNull(KC_ANDROID_SDK_INT)
     }
 }

--- a/test-android/src/androidUnitTest/digest
+++ b/test-android/src/androidUnitTest/digest
@@ -1,0 +1,1 @@
+../../../library/digest/src/commonTest/kotlin

--- a/test-android/src/androidUnitTest/kotlin/org/kotlincrypto/core/AndroidSdkIntUnitTest.kt
+++ b/test-android/src/androidUnitTest/kotlin/org/kotlincrypto/core/AndroidSdkIntUnitTest.kt
@@ -15,25 +15,14 @@
  **/
 package org.kotlincrypto.core
 
-@InternalKotlinCryptoApi
-public val KC_ANDROID_SDK_INT: Int? by lazy {
-    if (
-        System.getProperty("java.runtime.name")
-            ?.contains("android", ignoreCase = true) != true
-    ) {
-        // Not Android runtime
-        return@lazy null
-    }
+import kotlin.test.Test
+import kotlin.test.assertNull
 
-    try {
-        val clazz = Class.forName("android.os.Build\$VERSION")
+@OptIn(InternalKotlinCryptoApi::class)
+class AndroidSdkIntUnitTest {
 
-        try {
-            clazz?.getField("SDK_INT")?.getInt(null)
-        } catch (_: Throwable) {
-            clazz?.getField("SDK")?.get(null)?.toString()?.toIntOrNull()
-        }
-    } catch (_: Throwable) {
-        null
+    @Test
+    fun givenAndroidSdkInt_whenNOTAndroidRuntime_thenIsNull() {
+        assertNull(KC_ANDROID_SDK_INT)
     }
 }

--- a/test-android/src/androidUnitTest/mac
+++ b/test-android/src/androidUnitTest/mac
@@ -1,0 +1,1 @@
+../../../library/mac/src/commonTest/kotlin


### PR DESCRIPTION
Closes #50 

This PR adds to the `KC_ANDROID_SDK_INT` variable a check for android runtime. In the event it is not on android, the value will be `null`. If it **is** Android runtime, `android.os.Build.VERSION.SDK_INT` will be obtained via reflection and its value will be that of the devices API level.