### PR TITLE
Use `transitive` with API dependency modules

### DIFF
--- a/library/common/src/jvmMain/java9/module-info.java
+++ b/library/common/src/jvmMain/java9/module-info.java
@@ -1,5 +1,5 @@
 module org.kotlincrypto.core {
-    requires kotlin.stdlib;
+    requires transitive kotlin.stdlib;
 
     exports org.kotlincrypto.core;
 }

--- a/library/digest/src/jvmMain/java9/module-info.java
+++ b/library/digest/src/jvmMain/java9/module-info.java
@@ -1,6 +1,6 @@
 module org.kotlincrypto.core.digest {
-    requires kotlin.stdlib;
-    requires org.kotlincrypto.core;
+    requires transitive kotlin.stdlib;
+    requires transitive org.kotlincrypto.core;
 
     exports org.kotlincrypto.core.digest;
     exports org.kotlincrypto.core.digest.internal;

--- a/library/mac/src/jvmMain/java9/module-info.java
+++ b/library/mac/src/jvmMain/java9/module-info.java
@@ -1,6 +1,6 @@
 module org.kotlincrypto.core.mac {
-    requires kotlin.stdlib;
-    requires org.kotlincrypto.core;
+    requires transitive kotlin.stdlib;
+    requires transitive org.kotlincrypto.core;
 
     exports org.kotlincrypto.core.mac;
 }

--- a/library/xof/src/jvmMain/java9/module-info.java
+++ b/library/xof/src/jvmMain/java9/module-info.java
@@ -1,6 +1,6 @@
 module org.kotlincrypto.core.xof {
-    requires kotlin.stdlib;
-    requires org.kotlincrypto.core;
+    requires transitive kotlin.stdlib;
+    requires transitive org.kotlincrypto.core;
     requires org.kotlincrypto.endians;
 
     exports org.kotlincrypto.core.xof;


### PR DESCRIPTION
This PR adds to the `module-info.java` declarations the `transitive` key words in order to indicate the API dependency