### PR TITLE
Use multiplier variable to track compressions using Int instead of Long

### DIFF
--- a/library/digest/api/digest.api
+++ b/library/digest/api/digest.api
@@ -34,6 +34,6 @@ public abstract class org/kotlincrypto/core/digest/Digest : java/security/Messag
 }
 
 public abstract class org/kotlincrypto/core/digest/internal/DigestState {
-	public synthetic fun <init> (Ljava/lang/String;IIJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;IIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 

--- a/library/digest/api/digest.klib.api
+++ b/library/digest/api/digest.klib.api
@@ -33,5 +33,5 @@ abstract class org.kotlincrypto.core.digest/Digest : org.kotlincrypto.core/Algor
 }
 
 sealed class org.kotlincrypto.core.digest.internal/DigestState { // org.kotlincrypto.core.digest.internal/DigestState|null[0]
-    constructor <init>(kotlin/String, kotlin/Int, kotlin/Int, kotlin/Long) // org.kotlincrypto.core.digest.internal/DigestState.<init>|<init>(kotlin.String;kotlin.Int;kotlin.Int;kotlin.Long){}[0]
+    constructor <init>(kotlin/String, kotlin/Int, kotlin/Int, kotlin/Int, kotlin/Int) // org.kotlincrypto.core.digest.internal/DigestState.<init>|<init>(kotlin.String;kotlin.Int;kotlin.Int;kotlin.Int;kotlin.Int){}[0]
 }

--- a/library/digest/src/commonMain/kotlin/org/kotlincrypto/core/digest/internal/-Buffer.kt
+++ b/library/digest/src/commonMain/kotlin/org/kotlincrypto/core/digest/internal/-Buffer.kt
@@ -17,6 +17,7 @@
 
 package org.kotlincrypto.core.digest.internal
 
+import kotlin.concurrent.Volatile
 import kotlin.jvm.JvmInline
 import kotlin.jvm.JvmSynthetic
 
@@ -27,12 +28,14 @@ internal value class Buffer private constructor(internal val value: ByteArray) {
         algorithm: String,
         digestLength: Int,
         bufOffs: Int,
-        compressCount: Long,
+        compressCount: Int,
+        compressCountMultiplier: Int,
     ): DigestState = State(
         algorithm,
         digestLength,
         bufOffs,
         compressCount,
+        compressCountMultiplier,
         this,
     )
 
@@ -40,13 +43,15 @@ internal value class Buffer private constructor(internal val value: ByteArray) {
         algorithm: String,
         digestLength: Int,
         bufOffs: Int,
-        compressCount: Long,
+        compressCount: Int,
+        compressCountMultiplier: Int,
         buf: Buffer,
     ): DigestState(
         algorithm,
         digestLength,
         bufOffs,
         compressCount,
+        compressCountMultiplier,
     ) {
         val buf = Buffer(buf.value.copyOf())
     }

--- a/library/digest/src/commonMain/kotlin/org/kotlincrypto/core/digest/internal/-CommonPlatform.kt
+++ b/library/digest/src/commonMain/kotlin/org/kotlincrypto/core/digest/internal/-CommonPlatform.kt
@@ -30,3 +30,12 @@ internal inline fun ByteArray.commonCheckArgs(offset: Int, len: Int) {
     if (size - offset < len) throw IllegalArgumentException("Input too short")
     if (offset < 0 || len < 0 || offset > size - len) throw IndexOutOfBoundsException()
 }
+
+@Suppress("NOTHING_TO_INLINE")
+internal inline fun Int.commonCalculateCompressions(multiplier: Int): Long {
+    var count = this.toLong()
+    if (multiplier > 0) {
+        count += (Int.MAX_VALUE.toLong() * multiplier)
+    }
+    return count
+}

--- a/library/digest/src/commonMain/kotlin/org/kotlincrypto/core/digest/internal/DigestState.kt
+++ b/library/digest/src/commonMain/kotlin/org/kotlincrypto/core/digest/internal/DigestState.kt
@@ -17,10 +17,15 @@ package org.kotlincrypto.core.digest.internal
 
 /**
  * Used as a holder for copying/cloning of digests.
+ *
+ * **NOTE:** Can only be consumed once to instantiate a new Digest. This
+ * instance should **not** be held onto and should only be utilized by
+ * the `copy` function's implementation.
  * */
 public sealed class DigestState(
     internal val algorithm: String,
     internal val digestLength: Int,
     internal val bufOffs: Int,
-    internal val compressCount: Long,
+    internal val compressCount: Int,
+    internal val compressCountMultiplier: Int,
 )

--- a/library/digest/src/jvmTest/kotlin/org/kotlincrypto/core/digest/JvmDigestUnitTest.kt
+++ b/library/digest/src/jvmTest/kotlin/org/kotlincrypto/core/digest/JvmDigestUnitTest.kt
@@ -16,11 +16,13 @@
 package org.kotlincrypto.core.digest
 
 import org.kotlincrypto.core.digest.internal.DigestState
+import org.kotlincrypto.core.digest.internal.commonCalculateCompressions
 import java.lang.AssertionError
 import java.security.MessageDigest
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
 
 /**
  * Compares [Digest] functionality to [MessageDigest]
@@ -93,5 +95,25 @@ class JvmDigestUnitTest {
         jvm.update(bytes, 500, 1)
 
         assertContentEquals(jvm.digest(), wrap.digest())
+    }
+
+    // Test live here because functions are internal and the `test-android`
+    // module has symbolic links to commonTest which will cause crying.
+    @Test
+    fun givenCompressCount_whenMultiplier_thenCalculatesCorrectly() {
+        var actual = 0.commonCalculateCompressions(multiplier = 0)
+        assertEquals(0, actual)
+
+        actual = 1.commonCalculateCompressions(multiplier = 0)
+        assertEquals(1, actual)
+
+        actual = 0.commonCalculateCompressions(multiplier = 1)
+        assertEquals(Int.MAX_VALUE.toLong(), actual)
+
+        actual = 1.commonCalculateCompressions(multiplier = 1)
+        assertEquals(Int.MAX_VALUE.toLong() + 1, actual)
+
+        actual = 5.commonCalculateCompressions(multiplier = 10)
+        assertEquals((Int.MAX_VALUE.toLong() * 10) + 5, actual)
     }
 }


### PR DESCRIPTION
Closes #76 