### PR TITLE
Refactor `Mac` & `Digest` internals

### DIFF
--- a/benchmarks/src/commonMain/kotlin/org/kotlincrypto/core/benchmarks/DigestBenchmark.kt
+++ b/benchmarks/src/commonMain/kotlin/org/kotlincrypto/core/benchmarks/DigestBenchmark.kt
@@ -28,9 +28,9 @@ open class DigestBenchmark {
 
     private class TestDigest: Digest {
         constructor(): super("Benchmark", 32, 32)
-        private constructor(state: State): super(state)
+        private constructor(other: TestDigest): super(other)
         override fun resetProtected() {}
-        override fun copyProtected(state: State): Digest = TestDigest(state)
+        override fun copy(): TestDigest = TestDigest(this)
         override fun compressProtected(input: ByteArray, offset: Int) {}
         override fun digestProtected(buffer: ByteArray, offset: Int): ByteArray = ByteArray(0)
     }
@@ -40,9 +40,6 @@ open class DigestBenchmark {
 
     @Setup
     fun setup() { digest.update(bytes, 0, digest.blockSize()) }
-
-    @Benchmark
-    fun copy() = digest.copy()
 
     @Benchmark
     fun update() { digest.update(bytes) }

--- a/library/digest/api/digest.api
+++ b/library/digest/api/digest.api
@@ -1,13 +1,10 @@
 public abstract class org/kotlincrypto/core/digest/Digest : java/security/MessageDigest, java/lang/Cloneable, org/kotlincrypto/core/Algorithm, org/kotlincrypto/core/Copyable, org/kotlincrypto/core/Resettable, org/kotlincrypto/core/Updatable {
 	protected fun <init> (Ljava/lang/String;II)V
-	protected fun <init> (Lorg/kotlincrypto/core/digest/Digest$State;)V
+	protected fun <init> (Lorg/kotlincrypto/core/digest/Digest;)V
 	public final fun algorithm ()Ljava/lang/String;
 	public final fun blockSize ()I
 	public final fun clone ()Ljava/lang/Object;
 	protected abstract fun compressProtected ([BI)V
-	public synthetic fun copy ()Ljava/lang/Object;
-	public final fun copy ()Lorg/kotlincrypto/core/digest/Digest;
-	protected abstract fun copyProtected (Lorg/kotlincrypto/core/digest/Digest$State;)Lorg/kotlincrypto/core/digest/Digest;
 	public final fun digest ()[B
 	public final fun digest ([B)[B
 	public final fun digest ([BII)I
@@ -30,9 +27,6 @@ public abstract class org/kotlincrypto/core/digest/Digest : java/security/Messag
 	public final fun update ([BII)V
 	protected fun updateProtected (B)V
 	protected fun updateProtected ([BII)V
-}
-
-protected abstract class org/kotlincrypto/core/digest/Digest$State {
 }
 
 public abstract class org/kotlincrypto/core/digest/internal/DigestState {

--- a/library/digest/api/digest.klib.api
+++ b/library/digest/api/digest.klib.api
@@ -8,15 +8,13 @@
 // Library unique name: <org.kotlincrypto.core:digest>
 abstract class org.kotlincrypto.core.digest/Digest : org.kotlincrypto.core/Algorithm, org.kotlincrypto.core/Copyable<org.kotlincrypto.core.digest/Digest>, org.kotlincrypto.core/Resettable, org.kotlincrypto.core/Updatable { // org.kotlincrypto.core.digest/Digest|null[0]
     constructor <init>(kotlin/String, kotlin/Int, kotlin/Int) // org.kotlincrypto.core.digest/Digest.<init>|<init>(kotlin.String;kotlin.Int;kotlin.Int){}[0]
-    constructor <init>(org.kotlincrypto.core.digest/Digest.State) // org.kotlincrypto.core.digest/Digest.<init>|<init>(org.kotlincrypto.core.digest.Digest.State){}[0]
+    constructor <init>(org.kotlincrypto.core.digest/Digest) // org.kotlincrypto.core.digest/Digest.<init>|<init>(org.kotlincrypto.core.digest.Digest){}[0]
 
     abstract fun compressProtected(kotlin/ByteArray, kotlin/Int) // org.kotlincrypto.core.digest/Digest.compressProtected|compressProtected(kotlin.ByteArray;kotlin.Int){}[0]
-    abstract fun copyProtected(org.kotlincrypto.core.digest/Digest.State): org.kotlincrypto.core.digest/Digest // org.kotlincrypto.core.digest/Digest.copyProtected|copyProtected(org.kotlincrypto.core.digest.Digest.State){}[0]
     abstract fun digestProtected(kotlin/ByteArray, kotlin/Int): kotlin/ByteArray // org.kotlincrypto.core.digest/Digest.digestProtected|digestProtected(kotlin.ByteArray;kotlin.Int){}[0]
     abstract fun resetProtected() // org.kotlincrypto.core.digest/Digest.resetProtected|resetProtected(){}[0]
     final fun algorithm(): kotlin/String // org.kotlincrypto.core.digest/Digest.algorithm|algorithm(){}[0]
     final fun blockSize(): kotlin/Int // org.kotlincrypto.core.digest/Digest.blockSize|blockSize(){}[0]
-    final fun copy(): org.kotlincrypto.core.digest/Digest // org.kotlincrypto.core.digest/Digest.copy|copy(){}[0]
     final fun digest(): kotlin/ByteArray // org.kotlincrypto.core.digest/Digest.digest|digest(){}[0]
     final fun digest(kotlin/ByteArray): kotlin/ByteArray // org.kotlincrypto.core.digest/Digest.digest|digest(kotlin.ByteArray){}[0]
     final fun digestLength(): kotlin/Int // org.kotlincrypto.core.digest/Digest.digestLength|digestLength(){}[0]
@@ -29,10 +27,6 @@ abstract class org.kotlincrypto.core.digest/Digest : org.kotlincrypto.core/Algor
     final fun update(kotlin/ByteArray, kotlin/Int, kotlin/Int) // org.kotlincrypto.core.digest/Digest.update|update(kotlin.ByteArray;kotlin.Int;kotlin.Int){}[0]
     open fun updateProtected(kotlin/Byte) // org.kotlincrypto.core.digest/Digest.updateProtected|updateProtected(kotlin.Byte){}[0]
     open fun updateProtected(kotlin/ByteArray, kotlin/Int, kotlin/Int) // org.kotlincrypto.core.digest/Digest.updateProtected|updateProtected(kotlin.ByteArray;kotlin.Int;kotlin.Int){}[0]
-
-    sealed class State { // org.kotlincrypto.core.digest/Digest.State|null[0]
-        constructor <init>() // org.kotlincrypto.core.digest/Digest.State.<init>|<init>(){}[0]
-    }
 }
 
 sealed class org.kotlincrypto.core.digest.internal/DigestState { // org.kotlincrypto.core.digest.internal/DigestState|null[0]

--- a/library/digest/src/commonMain/kotlin/org/kotlincrypto/core/digest/Digest.kt
+++ b/library/digest/src/commonMain/kotlin/org/kotlincrypto/core/digest/Digest.kt
@@ -48,27 +48,28 @@ public expect abstract class Digest: Algorithm, Copyable<Digest>, Resettable, Up
     protected constructor(algorithm: String, blockSize: Int, digestLength: Int)
 
     /**
-     * Creates a new [Digest] for the copied [state] of another [Digest]
-     * instance.
+     * Creates a new [Digest] from [other], copying its state.
      *
      * Implementors of [Digest] should have a private secondary constructor
-     * that is utilized by its [copyProtected] implementation.
+     * that is utilized by its [copy] implementation.
      *
      * e.g.
      *
      *     public class SHA256: Digest {
      *
-     *         public constructor(): super("SHA-256", 64, 32) {
-     *             // Initialize...
-     *         }
-     *         private constructor(thiz: SHA256, state: State): super(state) {
+     *         // ...
+     *
+     *         private constructor(other: SHA256): super(other) {
      *             // Copy implementation details...
      *         }
-     *         protected override fun copyProtected(state: State): Digest = SHA256(this, state)
+     *
+     *         // Notice the updated return type
+     *         public override fun copy(): SHA256 = SHA256(this)
+     *
      *         // ...
      *     }
      * */
-    protected constructor(state: State)
+    protected constructor(other: Digest)
 
     /**
      * The number of byte blocks (in factors of 8) that the implementation
@@ -108,20 +109,6 @@ public expect abstract class Digest: Algorithm, Copyable<Digest>, Resettable, Up
 
     // See Resettable interface documentation
     public final override fun reset()
-
-    // See Copyable interface documentation
-    public final override fun copy(): Digest
-
-    /**
-     * Used as a holder for copying digest internals.
-     * */
-    protected sealed class State
-
-    /**
-     * Called by the public [copy] function which produces the [State]
-     * needed to create a wholly new instance.
-     * */
-    protected abstract fun copyProtected(state: State): Digest
 
     /**
      * Called whenever a full [blockSize] worth of bytes are available for processing,

--- a/library/digest/src/commonTest/kotlin/org/kotlincrypto/core/digest/TestDigest.kt
+++ b/library/digest/src/commonTest/kotlin/org/kotlincrypto/core/digest/TestDigest.kt
@@ -39,15 +39,11 @@ class TestDigest: Digest {
         this.reset = reset
     }
 
-    private constructor(
-        state: State,
-        compress: (input: ByteArray, offset: Int) -> Unit,
-        digest: (buffer: ByteArray, offset: Int) -> ByteArray,
-        reset: () -> Unit,
-    ): super(state) {
-        this.compress = compress
-        this.finalize = digest
-        this.reset = reset
+    private constructor(other: TestDigest): super(other) {
+        this.compress = other.compress
+        this.finalize = other.finalize
+        this.reset = other.reset
+        this.compressions = other.compressions
     }
 
     override fun compressProtected(input: ByteArray, offset: Int) {
@@ -64,9 +60,5 @@ class TestDigest: Digest {
         compressions = 0
     }
 
-    override fun copyProtected(state: State): Digest {
-        val d = TestDigest(state, compress, finalize, reset)
-        d.compressions = compressions
-        return d
-    }
+    override fun copy(): TestDigest = TestDigest(this)
 }

--- a/library/digest/src/jvmTest/kotlin/org/kotlincrypto/core/digest/JvmDigestUnitTest.kt
+++ b/library/digest/src/jvmTest/kotlin/org/kotlincrypto/core/digest/JvmDigestUnitTest.kt
@@ -33,11 +33,11 @@ class JvmDigestUnitTest {
         constructor(digest: MessageDigest, blockSize: Int): super(digest.algorithm, blockSize, digest.digestLength) {
             delegate = digest.clone() as MessageDigest
         }
-        private constructor(state: State, digest: MessageDigestWrap): super(state) {
-            delegate = digest.delegate.clone() as MessageDigest
+        private constructor(other: MessageDigestWrap): super(other) {
+            delegate = other.delegate.clone() as MessageDigest
         }
 
-        override fun copyProtected(state: State): Digest = MessageDigestWrap(state, this)
+        override fun copy(): MessageDigestWrap = MessageDigestWrap(this)
 
         override fun compressProtected(input: ByteArray, offset: Int) {
             delegate.update(input, offset, blockSize())

--- a/library/digest/src/nonJvmMain/kotlin/org/kotlincrypto/core/digest/Digest.kt
+++ b/library/digest/src/nonJvmMain/kotlin/org/kotlincrypto/core/digest/Digest.kt
@@ -59,31 +59,32 @@ public actual abstract class Digest: Algorithm, Copyable<Digest>, Resettable, Up
     }
 
     /**
-     * Creates a new [Digest] for the copied [state] of another [Digest]
-     * instance.
+     * Creates a new [Digest] from [other], copying its state.
      *
      * Implementors of [Digest] should have a private secondary constructor
-     * that is utilized by its [copyProtected] implementation.
+     * that is utilized by its [copy] implementation.
      *
      * e.g.
      *
      *     public class SHA256: Digest {
      *
-     *         public constructor(): super("SHA-256", 64, 32) {
-     *             // Initialize...
-     *         }
-     *         private constructor(thiz: SHA256, state: State): super(state) {
+     *         // ...
+     *
+     *         private constructor(other: SHA256): super(other) {
      *             // Copy implementation details...
      *         }
-     *         protected override fun copyProtected(state: State): Digest = SHA256(this, state)
+     *
+     *         // Notice the updated return type
+     *         public override fun copy(): SHA256 = SHA256(this)
+     *
      *         // ...
      *     }
      * */
-    protected actual constructor(state: State) {
-        this.algorithm = (state as RealState).algorithm
-        this.digestLength = state.digestLength
-        this.buf = state.buf.copy()
-        this.bufOffs = state.bufOffs
+    protected actual constructor(other: Digest) {
+        this.algorithm = other.algorithm
+        this.digestLength = other.digestLength
+        this.buf = other.buf.copy()
+        this.bufOffs = other.bufOffs
     }
 
     /**
@@ -143,19 +144,6 @@ public actual abstract class Digest: Algorithm, Copyable<Digest>, Resettable, Up
         resetProtected()
     }
 
-    // See Copyable interface documentation
-    public actual final override fun copy(): Digest = copyProtected(RealState())
-
-    /**
-     * Used as a holder for copying digest internals.
-     * */
-    protected actual sealed class State
-    /**
-     * Called by the [copy] function which produces the [State] needed
-     * to create a wholly new instance.
-     * */
-    protected actual abstract fun copyProtected(state: State): Digest
-
     /**
      * Called whenever a full [blockSize] worth of bytes are available for processing,
      * starting at index [offset] for the provided [input]. Implementations **must not**
@@ -209,11 +197,4 @@ public actual abstract class Digest: Algorithm, Copyable<Digest>, Resettable, Up
     public actual final override fun hashCode(): Int = buf.hashCode()
     /** @suppress */
     public actual final override fun toString(): String = commonToString()
-
-    private inner class RealState: State() {
-        val algorithm: String = this@Digest.algorithm()
-        val digestLength: Int = this@Digest.digestLength()
-        val bufOffs: Int = this@Digest.bufOffs
-        val buf: Buffer = this@Digest.buf
-    }
 }

--- a/library/mac/api/mac.api
+++ b/library/mac/api/mac.api
@@ -1,9 +1,7 @@
 public abstract class org/kotlincrypto/core/mac/Mac : javax/crypto/Mac, org/kotlincrypto/core/Algorithm, org/kotlincrypto/core/Copyable, org/kotlincrypto/core/Resettable, org/kotlincrypto/core/Updatable {
 	protected fun <init> (Ljava/lang/String;Lorg/kotlincrypto/core/mac/Mac$Engine;)V
+	protected fun <init> (Lorg/kotlincrypto/core/mac/Mac;)V
 	public final fun algorithm ()Ljava/lang/String;
-	public synthetic fun copy ()Ljava/lang/Object;
-	public final fun copy ()Lorg/kotlincrypto/core/mac/Mac;
-	protected abstract fun copy (Lorg/kotlincrypto/core/mac/Mac$Engine;)Lorg/kotlincrypto/core/mac/Mac;
 	public final fun equals (Ljava/lang/Object;)Z
 	public final fun hashCode ()I
 	public final fun macLength ()I
@@ -11,7 +9,7 @@ public abstract class org/kotlincrypto/core/mac/Mac : javax/crypto/Mac, org/kotl
 }
 
 protected abstract class org/kotlincrypto/core/mac/Mac$Engine : javax/crypto/MacSpi, java/lang/Cloneable, org/kotlincrypto/core/Copyable, org/kotlincrypto/core/Resettable, org/kotlincrypto/core/Updatable {
-	protected fun <init> (Lorg/kotlincrypto/core/mac/Mac$Engine$State;)V
+	protected fun <init> (Lorg/kotlincrypto/core/mac/Mac$Engine;)V
 	public fun <init> ([B)V
 	public final fun clone ()Ljava/lang/Object;
 	public abstract fun doFinal ()[B
@@ -26,9 +24,5 @@ protected abstract class org/kotlincrypto/core/mac/Mac$Engine : javax/crypto/Mac
 	public final fun hashCode ()I
 	public abstract fun macLength ()I
 	public fun update ([B)V
-}
-
-protected abstract class org/kotlincrypto/core/mac/Mac$Engine$State {
-	public fun <init> (Lorg/kotlincrypto/core/mac/Mac$Engine;)V
 }
 

--- a/library/mac/api/mac.api
+++ b/library/mac/api/mac.api
@@ -5,6 +5,7 @@ public abstract class org/kotlincrypto/core/mac/Mac : javax/crypto/Mac, org/kotl
 	public final fun equals (Ljava/lang/Object;)Z
 	public final fun hashCode ()I
 	public final fun macLength ()I
+	public final fun reset ([B)V
 	public final fun toString ()Ljava/lang/String;
 }
 
@@ -23,6 +24,7 @@ protected abstract class org/kotlincrypto/core/mac/Mac$Engine : javax/crypto/Mac
 	public final fun equals (Ljava/lang/Object;)Z
 	public final fun hashCode ()I
 	public abstract fun macLength ()I
+	public abstract fun reset ([B)V
 	public fun update ([B)V
 }
 

--- a/library/mac/api/mac.klib.api
+++ b/library/mac/api/mac.klib.api
@@ -8,10 +8,9 @@
 // Library unique name: <org.kotlincrypto.core:mac>
 abstract class org.kotlincrypto.core.mac/Mac : org.kotlincrypto.core/Algorithm, org.kotlincrypto.core/Copyable<org.kotlincrypto.core.mac/Mac>, org.kotlincrypto.core/Resettable, org.kotlincrypto.core/Updatable { // org.kotlincrypto.core.mac/Mac|null[0]
     constructor <init>(kotlin/String, org.kotlincrypto.core.mac/Mac.Engine) // org.kotlincrypto.core.mac/Mac.<init>|<init>(kotlin.String;org.kotlincrypto.core.mac.Mac.Engine){}[0]
+    constructor <init>(org.kotlincrypto.core.mac/Mac) // org.kotlincrypto.core.mac/Mac.<init>|<init>(org.kotlincrypto.core.mac.Mac){}[0]
 
-    abstract fun copy(org.kotlincrypto.core.mac/Mac.Engine): org.kotlincrypto.core.mac/Mac // org.kotlincrypto.core.mac/Mac.copy|copy(org.kotlincrypto.core.mac.Mac.Engine){}[0]
     final fun algorithm(): kotlin/String // org.kotlincrypto.core.mac/Mac.algorithm|algorithm(){}[0]
-    final fun copy(): org.kotlincrypto.core.mac/Mac // org.kotlincrypto.core.mac/Mac.copy|copy(){}[0]
     final fun doFinal(): kotlin/ByteArray // org.kotlincrypto.core.mac/Mac.doFinal|doFinal(){}[0]
     final fun doFinal(kotlin/ByteArray): kotlin/ByteArray // org.kotlincrypto.core.mac/Mac.doFinal|doFinal(kotlin.ByteArray){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // org.kotlincrypto.core.mac/Mac.equals|equals(kotlin.Any?){}[0]
@@ -25,16 +24,12 @@ abstract class org.kotlincrypto.core.mac/Mac : org.kotlincrypto.core/Algorithm, 
 
     abstract class Engine : org.kotlincrypto.core/Copyable<org.kotlincrypto.core.mac/Mac.Engine>, org.kotlincrypto.core/Resettable, org.kotlincrypto.core/Updatable { // org.kotlincrypto.core.mac/Mac.Engine|null[0]
         constructor <init>(kotlin/ByteArray) // org.kotlincrypto.core.mac/Mac.Engine.<init>|<init>(kotlin.ByteArray){}[0]
-        constructor <init>(org.kotlincrypto.core.mac/Mac.Engine.State) // org.kotlincrypto.core.mac/Mac.Engine.<init>|<init>(org.kotlincrypto.core.mac.Mac.Engine.State){}[0]
+        constructor <init>(org.kotlincrypto.core.mac/Mac.Engine) // org.kotlincrypto.core.mac/Mac.Engine.<init>|<init>(org.kotlincrypto.core.mac.Mac.Engine){}[0]
 
         abstract fun doFinal(): kotlin/ByteArray // org.kotlincrypto.core.mac/Mac.Engine.doFinal|doFinal(){}[0]
         abstract fun macLength(): kotlin/Int // org.kotlincrypto.core.mac/Mac.Engine.macLength|macLength(){}[0]
         final fun equals(kotlin/Any?): kotlin/Boolean // org.kotlincrypto.core.mac/Mac.Engine.equals|equals(kotlin.Any?){}[0]
         final fun hashCode(): kotlin/Int // org.kotlincrypto.core.mac/Mac.Engine.hashCode|hashCode(){}[0]
         open fun update(kotlin/ByteArray) // org.kotlincrypto.core.mac/Mac.Engine.update|update(kotlin.ByteArray){}[0]
-
-        abstract inner class State { // org.kotlincrypto.core.mac/Mac.Engine.State|null[0]
-            constructor <init>() // org.kotlincrypto.core.mac/Mac.Engine.State.<init>|<init>(){}[0]
-        }
     }
 }

--- a/library/mac/api/mac.klib.api
+++ b/library/mac/api/mac.klib.api
@@ -17,6 +17,7 @@ abstract class org.kotlincrypto.core.mac/Mac : org.kotlincrypto.core/Algorithm, 
     final fun hashCode(): kotlin/Int // org.kotlincrypto.core.mac/Mac.hashCode|hashCode(){}[0]
     final fun macLength(): kotlin/Int // org.kotlincrypto.core.mac/Mac.macLength|macLength(){}[0]
     final fun reset() // org.kotlincrypto.core.mac/Mac.reset|reset(){}[0]
+    final fun reset(kotlin/ByteArray) // org.kotlincrypto.core.mac/Mac.reset|reset(kotlin.ByteArray){}[0]
     final fun toString(): kotlin/String // org.kotlincrypto.core.mac/Mac.toString|toString(){}[0]
     final fun update(kotlin/Byte) // org.kotlincrypto.core.mac/Mac.update|update(kotlin.Byte){}[0]
     final fun update(kotlin/ByteArray) // org.kotlincrypto.core.mac/Mac.update|update(kotlin.ByteArray){}[0]
@@ -28,6 +29,7 @@ abstract class org.kotlincrypto.core.mac/Mac : org.kotlincrypto.core/Algorithm, 
 
         abstract fun doFinal(): kotlin/ByteArray // org.kotlincrypto.core.mac/Mac.Engine.doFinal|doFinal(){}[0]
         abstract fun macLength(): kotlin/Int // org.kotlincrypto.core.mac/Mac.Engine.macLength|macLength(){}[0]
+        abstract fun reset(kotlin/ByteArray) // org.kotlincrypto.core.mac/Mac.Engine.reset|reset(kotlin.ByteArray){}[0]
         final fun equals(kotlin/Any?): kotlin/Boolean // org.kotlincrypto.core.mac/Mac.Engine.equals|equals(kotlin.Any?){}[0]
         final fun hashCode(): kotlin/Int // org.kotlincrypto.core.mac/Mac.Engine.hashCode|hashCode(){}[0]
         open fun update(kotlin/ByteArray) // org.kotlincrypto.core.mac/Mac.Engine.update|update(kotlin.ByteArray){}[0]

--- a/library/mac/src/commonMain/kotlin/org/kotlincrypto/core/mac/Mac.kt
+++ b/library/mac/src/commonMain/kotlin/org/kotlincrypto/core/mac/Mac.kt
@@ -103,12 +103,14 @@ public expect abstract class Mac: Algorithm, Copyable<Mac>, Resettable, Updatabl
     // See Resettable interface documentation
     public final override fun reset()
 
-    /** @suppress */
-    public final override fun equals(other: Any?): Boolean
-    /** @suppress */
-    public final override fun hashCode(): Int
-    /** @suppress */
-    public final override fun toString(): String
+    /**
+     * Resets the [Mac] and will reinitialize it with the provided key.
+     *
+     * This is useful if wanting to clear the key before de-referencing.
+     *
+     * @throws [IllegalArgumentException] if [newKey] is empty.
+     * */
+    public fun reset(newKey: ByteArray)
 
     /**
      * Core abstraction for powering a [Mac] implementation.
@@ -145,9 +147,18 @@ public expect abstract class Mac: Algorithm, Copyable<Mac>, Resettable, Updatabl
         // See Updatable interface documentation
         public override fun update(input: ByteArray)
 
+        public abstract fun reset(newKey: ByteArray)
+
         /** @suppress */
         final override fun equals(other: Any?): Boolean
         /** @suppress */
         final override fun hashCode(): Int
     }
+
+    /** @suppress */
+    public final override fun equals(other: Any?): Boolean
+    /** @suppress */
+    public final override fun hashCode(): Int
+    /** @suppress */
+    public final override fun toString(): String
 }

--- a/library/mac/src/commonMain/kotlin/org/kotlincrypto/core/mac/Mac.kt
+++ b/library/mac/src/commonMain/kotlin/org/kotlincrypto/core/mac/Mac.kt
@@ -34,18 +34,43 @@ import org.kotlincrypto.core.*
  * https://docs.oracle.com/en/java/javase/11/docs/specs/security/standard-names.html#mac-algorithms
  *
  * @see [Engine]
- * @throws [IllegalArgumentException] if [algorithm] is blank
  * */
-public expect abstract class Mac
-@Throws(IllegalArgumentException::class)
-protected constructor(
-    algorithm: String,
-    engine: Engine,
-) : Algorithm,
-    Copyable<Mac>,
-    Resettable,
-    Updatable
-{
+public expect abstract class Mac: Algorithm, Copyable<Mac>, Resettable, Updatable {
+
+    /**
+     * Creates a new [Mac] for the specified parameters.
+     *
+     * @param [algorithm] See [Algorithm.algorithm]
+     * @param [engine] See [Engine]
+     * @throws [IllegalArgumentException] when:
+     *  - [algorithm] is blank
+     * */
+    @Throws(IllegalArgumentException::class)
+    protected constructor(algorithm: String, engine: Engine)
+
+    /**
+     * Creates a new [Mac] from [other], copying its [Engine] and state.
+     *
+     * Implementors of [Mac] should have a private secondary constructor
+     * that is utilized by its [copy] implementation.
+     *
+     * e.g.
+     *
+     *     public class HmacSHA256: Mac {
+     *
+     *         // ...
+     *
+     *         private constructor(other: HmacSHA256): super(other) {
+     *             // Copy implementation details...
+     *         }
+     *
+     *         // Notice the updated return type
+     *         public override fun copy(): HmacSHA256 = HmacSHA256(this)
+     *
+     *         // ...
+     *     }
+     * */
+    protected constructor(other: Mac)
 
     /**
      * The number of bytes the implementation returns when [doFinal] is called.
@@ -78,15 +103,6 @@ protected constructor(
     // See Resettable interface documentation
     public final override fun reset()
 
-    // See Copyable interface documentation
-    public final override fun copy(): Mac
-
-    /**
-     * Called by the public [copy] function which produces the
-     * [Engine] copy needed to create a wholly new instance.
-     * */
-    protected abstract fun copy(engineCopy: Engine): Mac
-
     /** @suppress */
     public final override fun equals(other: Any?): Boolean
     /** @suppress */
@@ -111,9 +127,9 @@ protected constructor(
         public constructor(key: ByteArray)
 
         /**
-         * Creates a new [Engine] for the copied [State]
+         * Creates a new [Engine] from [other], copying its state.
          * */
-        protected constructor(state: State)
+        protected constructor(other: Engine)
 
         /**
          * The number of bytes the implementation returns when [doFinal] is called.
@@ -133,8 +149,5 @@ protected constructor(
         final override fun equals(other: Any?): Boolean
         /** @suppress */
         final override fun hashCode(): Int
-
-        // Unfortunate API design for the copy functionality...
-        protected abstract inner class State()
     }
 }

--- a/library/mac/src/commonTest/kotlin/org/kotlincrypto/core/mac/MacUnitTest.kt
+++ b/library/mac/src/commonTest/kotlin/org/kotlincrypto/core/mac/MacUnitTest.kt
@@ -15,40 +15,40 @@
  **/
 package org.kotlincrypto.core.mac
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNotEquals
-import kotlin.test.fail
+import kotlin.test.*
 
 class MacUnitTest {
 
     @Test
     fun givenMac_whenEmptyKey_thenThrowsException() {
-        try {
+        assertFailsWith<IllegalArgumentException> {
             TestMac(ByteArray(0), "not empty")
-            fail()
-        } catch (_: IllegalArgumentException) {
-            // pass
         }
     }
 
     @Test
     fun givenMac_whenBlankAlgorithm_thenThrowsException() {
-        try {
+        assertFailsWith<IllegalArgumentException> {
             TestMac(ByteArray(5), "  ")
-            fail()
-        } catch (_: IllegalArgumentException) {
-            // pass
+        }
+    }
+
+    @Test
+    fun givenMac_whenResetWithEmptyKey_thenThrowsException() {
+        val mac = TestMac(ByteArray(5), "my algorithm")
+        assertFailsWith<IllegalArgumentException> {
+            mac.reset(ByteArray(0))
         }
     }
 
     @Test
     fun givenMac_whenInstantiated_thenInitializes() {
-        try {
-            TestMac(ByteArray(5), "not blank").update(5)
-            fail()
-        } catch (_: ConcurrentModificationException) {
-            // pass
+        val mac = TestMac(ByteArray(5), "not blank")
+        assertFailsWith<ConcurrentModificationException> {
+            // test mac throws ConcurrentModificationException
+            // on update for single byte input for verifying
+            // instantiation is in working  order.
+            mac.update(5)
         }
     }
 
@@ -56,7 +56,6 @@ class MacUnitTest {
     fun givenMac_whenCopied_thenIsNewInstance() {
         val mac = TestMac(ByteArray(5), "not blank")
         val copy = mac.copy()
-
         assertNotEquals(mac, copy)
     }
 

--- a/library/mac/src/commonTest/kotlin/org/kotlincrypto/core/mac/TestMac.kt
+++ b/library/mac/src/commonTest/kotlin/org/kotlincrypto/core/mac/TestMac.kt
@@ -25,8 +25,9 @@ class TestMac : Mac {
     ): super(algorithm, TestEngine(key, reset, doFinal))
 
     private constructor(algorithm: String, engine: TestEngine): super(algorithm, engine)
+    private constructor(other: TestMac): super(other)
 
-    override fun copy(engineCopy: Engine): Mac = TestMac(algorithm(), engineCopy as TestEngine)
+    override fun copy(): Mac = TestMac(this)
 
     private class TestEngine: Engine {
 
@@ -42,9 +43,9 @@ class TestMac : Mac {
             this.doFinal = doFinal
         }
 
-        private constructor(state: State, engine: TestEngine): super(state) {
-            this.reset = engine.reset
-            this.doFinal = engine.doFinal
+        private constructor(other: TestEngine): super(other) {
+            this.reset = other.reset
+            this.doFinal = other.doFinal
         }
 
         // To ensure that Java implementation initializes javax.crypto.Mac
@@ -58,6 +59,6 @@ class TestMac : Mac {
         override fun macLength(): Int = 0
         override fun doFinal(): ByteArray = doFinal.invoke()
 
-        override fun copy(): Engine = TestEngine(object : State() {}, this)
+        override fun copy(): Engine = TestEngine(this)
     }
 }

--- a/library/mac/src/commonTest/kotlin/org/kotlincrypto/core/mac/TestMac.kt
+++ b/library/mac/src/commonTest/kotlin/org/kotlincrypto/core/mac/TestMac.kt
@@ -21,8 +21,9 @@ class TestMac : Mac {
         key: ByteArray,
         algorithm: String,
         reset: () -> Unit = {},
+        rekey: (new: ByteArray) -> Unit = {},
         doFinal: () -> ByteArray = { ByteArray(0) },
-    ): super(algorithm, TestEngine(key, reset, doFinal))
+    ): super(algorithm, TestEngine(key, reset, rekey, doFinal))
 
     private constructor(algorithm: String, engine: TestEngine): super(algorithm, engine)
     private constructor(other: TestMac): super(other)
@@ -32,19 +33,23 @@ class TestMac : Mac {
     private class TestEngine: Engine {
 
         private val reset: () -> Unit
+        private val rekey: (new: ByteArray) -> Unit
         private val doFinal: () -> ByteArray
 
         constructor(
             key: ByteArray,
             reset: () -> Unit,
+            rekey: (new: ByteArray) -> Unit,
             doFinal: () -> ByteArray,
         ): super(key) {
             this.reset = reset
+            this.rekey = rekey
             this.doFinal = doFinal
         }
 
         private constructor(other: TestEngine): super(other) {
             this.reset = other.reset
+            this.rekey = other.rekey
             this.doFinal = other.doFinal
         }
 
@@ -54,6 +59,7 @@ class TestMac : Mac {
         override fun update(input: Byte) { throw ConcurrentModificationException() }
 
         override fun reset() { reset.invoke() }
+        override fun reset(newKey: ByteArray) { rekey.invoke(newKey) }
         override fun update(input: ByteArray) {}
         override fun update(input: ByteArray, offset: Int, len: Int) {}
         override fun macLength(): Int = 0

--- a/library/mac/src/jvmTest/kotlin/org/kotlincrypto/core/mac/JvmMacUnitTest.kt
+++ b/library/mac/src/jvmTest/kotlin/org/kotlincrypto/core/mac/JvmMacUnitTest.kt
@@ -18,9 +18,7 @@ package org.kotlincrypto.core.mac
 import junit.framework.TestCase.assertEquals
 import java.security.InvalidKeyException
 import javax.crypto.spec.SecretKeySpec
-import kotlin.test.Test
-import kotlin.test.assertNull
-import kotlin.test.fail
+import kotlin.test.*
 
 class JvmMacUnitTest {
 
@@ -34,22 +32,14 @@ class JvmMacUnitTest {
     }
 
     @Test
-    fun givenJvm_whenJavaxCryptoMacInitInvoked_thenThrowsException() {
-        val mac = TestMac(key, "My Algorithm")
-        val keySpec = SecretKeySpec(key, mac.algorithm())
+    fun givenJvm_whenJavaxCryptoMacInitInvoked_thenResetsWithNewKey() {
+        val oldKey = key
+        val newKey = oldKey.copyOf(oldKey.size - 4)
+        var rekey: ByteArray? = null
+        val mac = TestMac(key, "My Algorithm", rekey = { rekey = it })
 
-        try {
-            mac.init(keySpec)
-            fail()
-        } catch (_: InvalidKeyException) {
-            // pass
-        }
-
-        try {
-            mac.copy().init(keySpec)
-            fail()
-        } catch (_: InvalidKeyException) {
-            // pass
-        }
+        mac.init(SecretKeySpec(newKey, mac.algorithm()))
+        assertNotNull(rekey)
+        assertContentEquals(newKey, rekey)
     }
 }

--- a/library/mac/src/nonJvmMain/kotlin/org/kotlincrypto/core/mac/Mac.kt
+++ b/library/mac/src/nonJvmMain/kotlin/org/kotlincrypto/core/mac/Mac.kt
@@ -129,12 +129,17 @@ public actual abstract class Mac: Algorithm, Copyable<Mac>, Resettable, Updatabl
         engine.reset()
     }
 
-    /** @suppress */
-    public actual final override fun equals(other: Any?): Boolean = other is Mac && other.engine == engine
-    /** @suppress */
-    public actual final override fun hashCode(): Int = engine.hashCode()
-    /** @suppress */
-    public actual final override fun toString(): String = commonToString()
+    /**
+     * Resets the [Mac] and will reinitialize it with the provided key.
+     *
+     * This is useful if wanting to clear the key before de-referencing.
+     *
+     * @throws [IllegalArgumentException] if [newKey] is empty.
+     * */
+    public actual fun reset(newKey: ByteArray) {
+        require(newKey.isNotEmpty()) { "newKey cannot be empty" }
+        engine.reset(newKey)
+    }
 
     /**
      * Core abstraction for powering a [Mac] implementation.
@@ -173,6 +178,11 @@ public actual abstract class Mac: Algorithm, Copyable<Mac>, Resettable, Updatabl
         // See Updatable interface documentation
         public actual override fun update(input: ByteArray) { update(input, 0, input.size) }
 
+        /**
+         * Resets the [Engine] and will reinitialize it with the newly provided key.
+         * */
+        public actual abstract fun reset(newKey: ByteArray)
+
         private val code = Any()
 
         /** @suppress */
@@ -180,4 +190,11 @@ public actual abstract class Mac: Algorithm, Copyable<Mac>, Resettable, Updatabl
         /** @suppress */
         public actual final override fun hashCode(): Int = code.hashCode()
     }
+
+    /** @suppress */
+    public actual final override fun equals(other: Any?): Boolean = other is Mac && other.engine == engine
+    /** @suppress */
+    public actual final override fun hashCode(): Int = engine.hashCode()
+    /** @suppress */
+    public actual final override fun toString(): String = commonToString()
 }


### PR DESCRIPTION
PR updates `Mac` and `Digest` internals for far simpler `copy` implementation. Also updates `Mac` to now require `Mac.Engine` to support re-keying the instance via `reset(newKey: ByteArray)`