### PR TITLE
Ensure potentially stale input that has been buffered is zeroized before passing to `digestProtected`

### DIFF
--- a/library/digest/src/commonMain/kotlin/org/kotlincrypto/core/digest/Digest.kt
+++ b/library/digest/src/commonMain/kotlin/org/kotlincrypto/core/digest/Digest.kt
@@ -121,6 +121,9 @@ public expect abstract class Digest: Algorithm, Copyable<Digest>, Resettable, Up
      * Called to complete the computation, providing any input that may be buffered
      * and awaiting processing.
      *
+     * **NOTE:** The buffer from [bufPos] to the end will always be zeroized to clear
+     * any potentially stale input left over from a previous state.
+     *
      * @param [buf] Unprocessed input
      * @param [bufPos] The index at which the **next** input would be placed into [buf]
      * */

--- a/library/digest/src/commonMain/kotlin/org/kotlincrypto/core/digest/internal/-Buffer.kt
+++ b/library/digest/src/commonMain/kotlin/org/kotlincrypto/core/digest/internal/-Buffer.kt
@@ -123,3 +123,13 @@ internal inline fun Buffer.commonDigest(
     reset()
     return final
 }
+
+@Suppress("NOTHING_TO_INLINE")
+internal inline fun Buffer.commonReset(
+    resetProtected: () -> Unit,
+    bufPosSet: (zero: Int) -> Unit,
+) {
+    value.fill(0)
+    bufPosSet(0)
+    resetProtected()
+}

--- a/library/digest/src/commonMain/kotlin/org/kotlincrypto/core/digest/internal/-Buffer.kt
+++ b/library/digest/src/commonMain/kotlin/org/kotlincrypto/core/digest/internal/-Buffer.kt
@@ -110,3 +110,16 @@ internal inline fun Buffer.commonUpdate(
     // Update globals
     bufPosSet(posBuf)
 }
+
+@Suppress("NOTHING_TO_INLINE")
+internal inline fun Buffer.commonDigest(
+    bufPos: Int,
+    digestProtected: (buf: ByteArray, bufPos: Int) -> ByteArray,
+    reset: () -> Unit,
+): ByteArray {
+    // Zeroize any stale input that may be left in the buffer
+    value.fill(0, bufPos)
+    val final = digestProtected(value, bufPos)
+    reset()
+    return final
+}

--- a/library/digest/src/commonTest/kotlin/org/kotlincrypto/core/digest/TestDigest.kt
+++ b/library/digest/src/commonTest/kotlin/org/kotlincrypto/core/digest/TestDigest.kt
@@ -18,7 +18,7 @@ package org.kotlincrypto.core.digest
 class TestDigest: Digest {
 
     private val compress: (input: ByteArray, offset: Int) -> Unit
-    private val finalize: (buffer: ByteArray, offset: Int) -> ByteArray
+    private val finalize: (buf: ByteArray, bufPos: Int) -> ByteArray
     private val reset: () -> Unit
 
     constructor(algorithm: String): this(algorithm, 64)
@@ -31,7 +31,7 @@ class TestDigest: Digest {
         blockSize: Int = 64,
         digestLength: Int = 32,
         compress: (input: ByteArray, offset: Int) -> Unit = { _, _ -> },
-        digest: (buffer: ByteArray, offset: Int) -> ByteArray = { _, _ -> ByteArray(blockSize) },
+        digest: (buf: ByteArray, bufPos: Int) -> ByteArray = { _, _ -> ByteArray(blockSize) },
         reset: () -> Unit = {},
     ): super(algorithm, blockSize, digestLength) {
         this.compress = compress

--- a/library/digest/src/jvmMain/kotlin/org/kotlincrypto/core/digest/Digest.kt
+++ b/library/digest/src/jvmMain/kotlin/org/kotlincrypto/core/digest/Digest.kt
@@ -124,11 +124,11 @@ public actual abstract class Digest: MessageDigest, Algorithm, Cloneable, Copyab
      * Completes the computation, performing final operations and returning
      * the resultant array of bytes. The [Digest] is [reset] afterward.
      * */
-    public actual final override fun digest(): ByteArray {
-        val final = digestProtected(buf.value, bufPos)
-        reset()
-        return final
-    }
+    public actual final override fun digest(): ByteArray = buf.commonDigest(
+        bufPos = bufPos,
+        digestProtected = ::digestProtected,
+        reset = ::reset
+    )
 
     /**
      * Updates the instance with provided [input], then completes the computation,
@@ -157,6 +157,9 @@ public actual abstract class Digest: MessageDigest, Algorithm, Cloneable, Copyab
     /**
      * Called to complete the computation, providing any input that may be buffered
      * and awaiting processing.
+     *
+     * **NOTE:** The buffer from [bufPos] to the end will always be zeroized to clear
+     * any potentially stale input left over from a previous state.
      *
      * @param [buf] Unprocessed input
      * @param [bufPos] The index at which the **next** input would be placed into [buf]

--- a/library/digest/src/jvmMain/kotlin/org/kotlincrypto/core/digest/Digest.kt
+++ b/library/digest/src/jvmMain/kotlin/org/kotlincrypto/core/digest/Digest.kt
@@ -142,9 +142,7 @@ public actual abstract class Digest: MessageDigest, Algorithm, Cloneable, Copyab
 
     // See Resettable interface documentation
     public actual final override fun reset() {
-        buf.value.fill(0)
-        bufPos = 0
-        resetProtected()
+        buf.commonReset(::resetProtected) { bufPos = it }
     }
 
     /**

--- a/library/digest/src/nonJvmMain/kotlin/org/kotlincrypto/core/digest/Digest.kt
+++ b/library/digest/src/nonJvmMain/kotlin/org/kotlincrypto/core/digest/Digest.kt
@@ -121,11 +121,11 @@ public actual abstract class Digest: Algorithm, Copyable<Digest>, Resettable, Up
      * Completes the computation, performing final operations and returning
      * the resultant array of bytes. The [Digest] is [reset] afterward.
      * */
-    public actual fun digest(): ByteArray {
-        val final = digestProtected(buf.value, bufPos)
-        reset()
-        return final
-    }
+    public actual fun digest(): ByteArray = buf.commonDigest(
+        bufPos = bufPos,
+        digestProtected = ::digestProtected,
+        reset = ::reset,
+    )
 
     /**
      * Updates the instance with provided [input], then completes the computation,
@@ -154,6 +154,9 @@ public actual abstract class Digest: Algorithm, Copyable<Digest>, Resettable, Up
     /**
      * Called to complete the computation, providing any input that may be buffered
      * and awaiting processing.
+     *
+     * **NOTE:** The buffer from [bufPos] to the end will always be zeroized to clear
+     * any potentially stale input left over from a previous state.
      *
      * @param [buf] Unprocessed input
      * @param [bufPos] The index at which the **next** input would be placed into [buf]

--- a/library/digest/src/nonJvmMain/kotlin/org/kotlincrypto/core/digest/Digest.kt
+++ b/library/digest/src/nonJvmMain/kotlin/org/kotlincrypto/core/digest/Digest.kt
@@ -139,9 +139,7 @@ public actual abstract class Digest: Algorithm, Copyable<Digest>, Resettable, Up
 
     // See Resettable interface documentation
     public actual final override fun reset() {
-        buf.value.fill(0)
-        bufPos = 0
-        resetProtected()
+        buf.commonReset(::resetProtected) { bufPos = it }
     }
 
     /**


### PR DESCRIPTION
Closes #91 