### PR TITLE
Add helpers for finalizing `Counter`

### DIFF
--- a/library/core/api/core.api
+++ b/library/core/api/core.api
@@ -21,6 +21,7 @@ public final class org/kotlincrypto/core/Counter$Bit32 : org/kotlincrypto/core/C
 	public fun <init> (III)V
 	public synthetic fun copy ()Ljava/lang/Object;
 	public fun copy ()Lorg/kotlincrypto/core/Counter$Bit32;
+	public final fun final (I)Lorg/kotlincrypto/core/Counter$Bit32$Final;
 	public final fun hi ()I
 	public fun increment ()V
 	public final fun lo ()I
@@ -28,6 +29,17 @@ public final class org/kotlincrypto/core/Counter$Bit32 : org/kotlincrypto/core/C
 }
 
 public final class org/kotlincrypto/core/Counter$Bit32$Companion {
+}
+
+public final class org/kotlincrypto/core/Counter$Bit32$Final {
+	public final field hi I
+	public final field lo I
+	public final fun asBits ()Lorg/kotlincrypto/core/Counter$Bit32$Final;
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class org/kotlincrypto/core/Counter$Bit64 : org/kotlincrypto/core/Counter {
@@ -38,6 +50,7 @@ public final class org/kotlincrypto/core/Counter$Bit64 : org/kotlincrypto/core/C
 	public fun <init> (JJJ)V
 	public synthetic fun copy ()Ljava/lang/Object;
 	public fun copy ()Lorg/kotlincrypto/core/Counter$Bit64;
+	public final fun final (I)Lorg/kotlincrypto/core/Counter$Bit64$Final;
 	public final fun hi ()J
 	public fun increment ()V
 	public final fun lo ()J
@@ -45,6 +58,17 @@ public final class org/kotlincrypto/core/Counter$Bit64 : org/kotlincrypto/core/C
 }
 
 public final class org/kotlincrypto/core/Counter$Bit64$Companion {
+}
+
+public final class org/kotlincrypto/core/Counter$Bit64$Final {
+	public final field hi J
+	public final field lo J
+	public final fun asBits ()Lorg/kotlincrypto/core/Counter$Bit64$Final;
+	public final fun component1 ()J
+	public final fun component2 ()J
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public abstract interface annotation class org/kotlincrypto/core/ExperimentalKotlinCryptoApi : java/lang/annotation/Annotation {

--- a/library/core/api/core.klib.api
+++ b/library/core/api/core.klib.api
@@ -51,8 +51,23 @@ sealed class org.kotlincrypto.core/Counter : org.kotlincrypto.core/Copyable<org.
             final fun <get-lo>(): kotlin/Int // org.kotlincrypto.core/Counter.Bit32.lo.<get-lo>|<get-lo>(){}[0]
 
         final fun copy(): org.kotlincrypto.core/Counter.Bit32 // org.kotlincrypto.core/Counter.Bit32.copy|copy(){}[0]
+        final fun final(kotlin/Int): org.kotlincrypto.core/Counter.Bit32.Final // org.kotlincrypto.core/Counter.Bit32.final|final(kotlin.Int){}[0]
         final fun increment() // org.kotlincrypto.core/Counter.Bit32.increment|increment(){}[0]
         final fun reset() // org.kotlincrypto.core/Counter.Bit32.reset|reset(){}[0]
+
+        final class Final { // org.kotlincrypto.core/Counter.Bit32.Final|null[0]
+            final val hi // org.kotlincrypto.core/Counter.Bit32.Final.hi|{}hi[0]
+                final fun <get-hi>(): kotlin/Int // org.kotlincrypto.core/Counter.Bit32.Final.hi.<get-hi>|<get-hi>(){}[0]
+            final val lo // org.kotlincrypto.core/Counter.Bit32.Final.lo|{}lo[0]
+                final fun <get-lo>(): kotlin/Int // org.kotlincrypto.core/Counter.Bit32.Final.lo.<get-lo>|<get-lo>(){}[0]
+
+            final fun asBits(): org.kotlincrypto.core/Counter.Bit32.Final // org.kotlincrypto.core/Counter.Bit32.Final.asBits|asBits(){}[0]
+            final fun component1(): kotlin/Int // org.kotlincrypto.core/Counter.Bit32.Final.component1|component1(){}[0]
+            final fun component2(): kotlin/Int // org.kotlincrypto.core/Counter.Bit32.Final.component2|component2(){}[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // org.kotlincrypto.core/Counter.Bit32.Final.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // org.kotlincrypto.core/Counter.Bit32.Final.hashCode|hashCode(){}[0]
+            final fun toString(): kotlin/String // org.kotlincrypto.core/Counter.Bit32.Final.toString|toString(){}[0]
+        }
 
         final object Companion { // org.kotlincrypto.core/Counter.Bit32.Companion|null[0]
             final const val MAX_INCREMENT // org.kotlincrypto.core/Counter.Bit32.Companion.MAX_INCREMENT|{}MAX_INCREMENT[0]
@@ -73,8 +88,23 @@ sealed class org.kotlincrypto.core/Counter : org.kotlincrypto.core/Copyable<org.
             final fun <get-lo>(): kotlin/Long // org.kotlincrypto.core/Counter.Bit64.lo.<get-lo>|<get-lo>(){}[0]
 
         final fun copy(): org.kotlincrypto.core/Counter.Bit64 // org.kotlincrypto.core/Counter.Bit64.copy|copy(){}[0]
+        final fun final(kotlin/Int): org.kotlincrypto.core/Counter.Bit64.Final // org.kotlincrypto.core/Counter.Bit64.final|final(kotlin.Int){}[0]
         final fun increment() // org.kotlincrypto.core/Counter.Bit64.increment|increment(){}[0]
         final fun reset() // org.kotlincrypto.core/Counter.Bit64.reset|reset(){}[0]
+
+        final class Final { // org.kotlincrypto.core/Counter.Bit64.Final|null[0]
+            final val hi // org.kotlincrypto.core/Counter.Bit64.Final.hi|{}hi[0]
+                final fun <get-hi>(): kotlin/Long // org.kotlincrypto.core/Counter.Bit64.Final.hi.<get-hi>|<get-hi>(){}[0]
+            final val lo // org.kotlincrypto.core/Counter.Bit64.Final.lo|{}lo[0]
+                final fun <get-lo>(): kotlin/Long // org.kotlincrypto.core/Counter.Bit64.Final.lo.<get-lo>|<get-lo>(){}[0]
+
+            final fun asBits(): org.kotlincrypto.core/Counter.Bit64.Final // org.kotlincrypto.core/Counter.Bit64.Final.asBits|asBits(){}[0]
+            final fun component1(): kotlin/Long // org.kotlincrypto.core/Counter.Bit64.Final.component1|component1(){}[0]
+            final fun component2(): kotlin/Long // org.kotlincrypto.core/Counter.Bit64.Final.component2|component2(){}[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // org.kotlincrypto.core/Counter.Bit64.Final.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // org.kotlincrypto.core/Counter.Bit64.Final.hashCode|hashCode(){}[0]
+            final fun toString(): kotlin/String // org.kotlincrypto.core/Counter.Bit64.Final.toString|toString(){}[0]
+        }
 
         final object Companion { // org.kotlincrypto.core/Counter.Bit64.Companion|null[0]
             final const val MAX_INCREMENT // org.kotlincrypto.core/Counter.Bit64.Companion.MAX_INCREMENT|{}MAX_INCREMENT[0]

--- a/library/core/src/commonMain/kotlin/org/kotlincrypto/core/Counter.kt
+++ b/library/core/src/commonMain/kotlin/org/kotlincrypto/core/Counter.kt
@@ -17,7 +17,6 @@ package org.kotlincrypto.core
 
 import org.kotlincrypto.core.Counter.Bit32.Companion.MAX_INCREMENT
 import org.kotlincrypto.core.Counter.Bit64.Companion.MAX_INCREMENT
-import org.kotlincrypto.core.Counter.Bit64.Final
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmName
 

--- a/library/core/src/commonTest/kotlin/org/kotlincrypto/core/CounterUnitTest.kt
+++ b/library/core/src/commonTest/kotlin/org/kotlincrypto/core/CounterUnitTest.kt
@@ -143,4 +143,70 @@ class CounterUnitTest {
         copy.increment()
         assertNotEquals(expected.lo, copy.lo)
     }
+
+    @Test
+    fun givenBit32_whenFinal_thenAdditionalValueIsAsExpected() {
+        val counter = Counter.Bit32(-8, 0, 8)
+
+        val (lo1, hi1) = counter.final(additional = 9)
+        assertEquals(1, lo1)
+        assertEquals(1, hi1)
+
+        val (lo2, hi2) = counter.final(additional = 8)
+        assertEquals(0, lo2)
+        assertEquals(1, hi2)
+
+        val (lo3, hi3) = counter.final(additional = 7)
+        assertEquals(-1, lo3)
+        assertEquals(0, hi3)
+    }
+
+    @Test
+    fun givenBit64_whenFinal_thenAdditionalValueIsAsExpected() {
+        val counter = Counter.Bit64(-8, 0, 8)
+
+        val (lo1, hi1) = counter.final(additional = 9)
+        assertEquals(1, lo1)
+        assertEquals(1, hi1)
+
+        val (lo2, hi2) = counter.final(additional = 8)
+        assertEquals(0, lo2)
+        assertEquals(1, hi2)
+
+        val (lo3, hi3) = counter.final(additional = 7)
+        assertEquals(-1, lo3)
+        assertEquals(0, hi3)
+    }
+
+    @Test
+    fun givenBit32Final_whenAsBits_thenConvertsAsExpected() {
+        val number = 5551889119L
+        val final = Counter.Bit32.Final(lo = number.toInt(), hi = number.rotateLeft(32).toInt())
+        val bits = final.asBits()
+        assertNotEquals(final, bits)
+
+        // Should return same instance (already bits)
+        assertEquals(bits, bits.asBits())
+
+        val expected = number * Byte.SIZE_BITS
+        val actual = ((bits.hi.toLong() and 0xffffffff) shl 32) or (bits.lo.toLong() and 0xffffffff)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun givenBit64Final_whenAsBits_thenConvertsAsExpected() {
+        val number = 5551889119L
+        val final = Counter.Bit64.Final(lo = number, hi = 1)
+        val bits = final.asBits()
+        assertNotEquals(final, bits)
+
+        // Should return same instance (already bits)
+        assertEquals(bits, bits.asBits())
+
+        var expected = Long.MAX_VALUE
+        expected += number + 1
+        expected *= Byte.SIZE_BITS
+        val actual = ((bits.hi and 0xffffffff) shl 32) or (bits.lo and 0xffffffff)
+        assertEquals(expected, actual)
+    }
 }


### PR DESCRIPTION
Adds convenience functionality for finalizing the `Counter` (for when `digestProtected` is called), as well as converting those values from bytes of input (if that's what was being counted) to bits.