### PR TITLE
Throw `InvalidKeyException` and `InvalidParameterException` instead of `IllegalArgumentException`

### DIFF
--- a/library/digest/src/commonMain/kotlin/org/kotlincrypto/core/digest/Digest.kt
+++ b/library/digest/src/commonMain/kotlin/org/kotlincrypto/core/digest/Digest.kt
@@ -18,6 +18,7 @@
 package org.kotlincrypto.core.digest
 
 import org.kotlincrypto.core.*
+import org.kotlincrypto.error.InvalidParameterException
 import org.kotlincrypto.error.ShortBufferException
 
 /**
@@ -39,13 +40,13 @@ public expect abstract class Digest: Algorithm, Copyable<Digest>, Resettable, Up
      * @param [algorithm] See [Algorithm.algorithm]
      * @param [blockSize] See [Digest.blockSize]
      * @param [digestLength] See [Digest.digestLength]
-     * @throws [IllegalArgumentException] when:
+     * @throws [InvalidParameterException] when:
      *  - [algorithm] is blank
      *  - [blockSize] is less than or equal to 0
      *  - [blockSize] is not a factor of 8
      *  - [digestLength] is negative
      * */
-    @Throws(IllegalArgumentException::class)
+    @Throws(InvalidParameterException::class)
     protected constructor(algorithm: String, blockSize: Int, digestLength: Int)
 
     /**

--- a/library/digest/src/commonMain/kotlin/org/kotlincrypto/core/digest/internal/-Buffer.kt
+++ b/library/digest/src/commonMain/kotlin/org/kotlincrypto/core/digest/internal/-Buffer.kt
@@ -18,7 +18,9 @@
 package org.kotlincrypto.core.digest.internal
 
 import org.kotlincrypto.core.digest.Digest
+import org.kotlincrypto.error.InvalidParameterException
 import org.kotlincrypto.error.ShortBufferException
+import org.kotlincrypto.error.requireParam
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
@@ -27,17 +29,17 @@ import kotlin.jvm.JvmInline
 @JvmInline
 internal value class Buffer internal constructor(internal val value: ByteArray)
 
-@Throws(IllegalArgumentException::class)
+@Throws(InvalidParameterException::class)
 @Suppress("UnusedReceiverParameter")
 internal inline fun Digest.initializeBuffer(
     algorithm: String,
     blockSize: Int,
     digestLength: Int,
 ): Buffer {
-    require(algorithm.isNotBlank()) { "algorithm cannot be blank" }
-    require(blockSize > 0) { "blockSize must be greater than 0" }
-    require(blockSize % 8 == 0) { "blockSize must be a factor of 8" }
-    require(digestLength >= 0) { "digestLength cannot be negative" }
+    requireParam(algorithm.isNotBlank()) { "algorithm cannot be blank" }
+    requireParam(blockSize > 0) { "blockSize must be greater than 0" }
+    requireParam(blockSize % 8 == 0) { "blockSize must be a factor of 8" }
+    requireParam(digestLength >= 0) { "digestLength cannot be negative" }
     return Buffer(ByteArray(blockSize))
 }
 

--- a/library/digest/src/commonTest/kotlin/org/kotlincrypto/core/digest/DigestUnitTest.kt
+++ b/library/digest/src/commonTest/kotlin/org/kotlincrypto/core/digest/DigestUnitTest.kt
@@ -15,6 +15,7 @@
  **/
 package org.kotlincrypto.core.digest
 
+import org.kotlincrypto.error.InvalidParameterException
 import org.kotlincrypto.error.ShortBufferException
 import kotlin.random.Random
 import kotlin.test.*
@@ -39,13 +40,7 @@ class DigestUnitTest: AbstractTestUpdateExceptions() {
     fun givenDigest_whenLengthNegative_thenThrowsException() {
         // accepts 0 length
         TestDigest(digestLength = 0)
-
-        try {
-            TestDigest(digestLength = -1)
-            fail()
-        } catch (_: IllegalArgumentException) {
-            // pass
-        }
+        assertFailsWith<InvalidParameterException> { TestDigest(digestLength = -1) }
     }
 
     @Test

--- a/library/digest/src/jvmMain/kotlin/org/kotlincrypto/core/digest/Digest.kt
+++ b/library/digest/src/jvmMain/kotlin/org/kotlincrypto/core/digest/Digest.kt
@@ -19,6 +19,7 @@ package org.kotlincrypto.core.digest
 
 import org.kotlincrypto.core.*
 import org.kotlincrypto.core.digest.internal.*
+import org.kotlincrypto.error.InvalidParameterException
 import org.kotlincrypto.error.ShortBufferException
 import java.nio.ByteBuffer
 import java.security.DigestException
@@ -48,13 +49,13 @@ public actual abstract class Digest: MessageDigest, Algorithm, Cloneable, Copyab
      * @param [algorithm] See [Algorithm.algorithm]
      * @param [blockSize] See [Digest.blockSize]
      * @param [digestLength] See [Digest.digestLength]
-     * @throws [IllegalArgumentException] when:
+     * @throws [InvalidParameterException] when:
      *  - [algorithm] is blank
      *  - [blockSize] is less than or equal to 0
      *  - [blockSize] is not a factor of 8
      *  - [digestLength] is negative
      * */
-    @Throws(IllegalArgumentException::class)
+    @Throws(InvalidParameterException::class)
     protected actual constructor(algorithm: String, blockSize: Int, digestLength: Int): super(algorithm) {
         this.buf = initializeBuffer(algorithm, blockSize, digestLength)
         this.digestLength = digestLength

--- a/library/digest/src/nonJvmMain/kotlin/org/kotlincrypto/core/digest/Digest.kt
+++ b/library/digest/src/nonJvmMain/kotlin/org/kotlincrypto/core/digest/Digest.kt
@@ -19,6 +19,7 @@ package org.kotlincrypto.core.digest
 
 import org.kotlincrypto.core.*
 import org.kotlincrypto.core.digest.internal.*
+import org.kotlincrypto.error.InvalidParameterException
 import org.kotlincrypto.error.ShortBufferException
 
 /**
@@ -45,13 +46,13 @@ public actual abstract class Digest: Algorithm, Copyable<Digest>, Resettable, Up
      * @param [algorithm] See [Algorithm.algorithm]
      * @param [blockSize] See [Digest.blockSize]
      * @param [digestLength] See [Digest.digestLength]
-     * @throws [IllegalArgumentException] when:
+     * @throws [InvalidParameterException] when:
      *  - [algorithm] is blank
      *  - [blockSize] is less than or equal to 0
      *  - [blockSize] is not a factor of 8
      *  - [digestLength] is negative
      * */
-    @Throws(IllegalArgumentException::class)
+    @Throws(InvalidParameterException::class)
     protected actual constructor(algorithm: String, blockSize: Int, digestLength: Int) {
         this.buf = initializeBuffer(algorithm, blockSize, digestLength)
         this.algorithm = algorithm

--- a/library/mac/src/commonMain/kotlin/org/kotlincrypto/core/mac/Mac.kt
+++ b/library/mac/src/commonMain/kotlin/org/kotlincrypto/core/mac/Mac.kt
@@ -18,6 +18,7 @@
 package org.kotlincrypto.core.mac
 
 import org.kotlincrypto.core.*
+import org.kotlincrypto.error.InvalidKeyException
 import org.kotlincrypto.error.InvalidParameterException
 import org.kotlincrypto.error.ShortBufferException
 
@@ -123,7 +124,7 @@ public expect abstract class Mac: Algorithm, Copyable<Mac>, Resettable, Updatabl
      * This is useful if wanting to zero out the key before de-referencing.
      *
      * @see [clearKey]
-     * @throws [IllegalArgumentException] if [newKey] is empty, or of a length
+     * @throws [InvalidKeyException] if [newKey] is empty, or of a length
      *   inappropriate for the [Mac] implementation.
      * */
     public fun reset(newKey: ByteArray)
@@ -161,9 +162,9 @@ public expect abstract class Mac: Algorithm, Copyable<Mac>, Resettable, Updatabl
          * or [Engine.doFinalInto] have been invoked).
          *
          * @param [key] The key that this [Engine] instance will use to apply its function to
-         * @throws [IllegalArgumentException] if [key] is empty
+         * @throws [InvalidKeyException] if [key] is empty
          * */
-        @Throws(IllegalArgumentException::class)
+        @Throws(InvalidKeyException::class)
         public constructor(key: ByteArray)
 
         /**
@@ -171,9 +172,9 @@ public expect abstract class Mac: Algorithm, Copyable<Mac>, Resettable, Updatabl
          *
          * @param [key] the key that this [Engine] instance will use to apply its function to
          * @param [resetOnDoFinal] See [Engine.resetOnDoFinal] documentation
-         * @throws [IllegalArgumentException] if [key] is empty
+         * @throws [InvalidKeyException] if [key] is empty
          * */
-        @Throws(IllegalArgumentException::class)
+        @Throws(InvalidKeyException::class)
         public constructor(key: ByteArray, resetOnDoFinal: Boolean)
 
         /**
@@ -218,10 +219,10 @@ public expect abstract class Mac: Algorithm, Copyable<Mac>, Resettable, Updatabl
          * before passing it here. Implementations should ensure any old key material
          * is zeroed out.
          *
-         * @throws [IllegalArgumentException] if [newKey] is a length inappropriate
-         *   for the [Mac] implementation.
+         * @throws [InvalidKeyException] if [newKey] is a length inappropriate
+         *   for the [Engine] implementation.
          * */
-        @Throws(IllegalArgumentException::class)
+        @Throws(InvalidKeyException::class)
         public abstract fun reset(newKey: ByteArray)
 
         /** @suppress */

--- a/library/mac/src/commonMain/kotlin/org/kotlincrypto/core/mac/Mac.kt
+++ b/library/mac/src/commonMain/kotlin/org/kotlincrypto/core/mac/Mac.kt
@@ -18,6 +18,7 @@
 package org.kotlincrypto.core.mac
 
 import org.kotlincrypto.core.*
+import org.kotlincrypto.error.InvalidParameterException
 import org.kotlincrypto.error.ShortBufferException
 
 /**
@@ -43,10 +44,10 @@ public expect abstract class Mac: Algorithm, Copyable<Mac>, Resettable, Updatabl
      *
      * @param [algorithm] See [Algorithm.algorithm]
      * @param [engine] See [Engine]
-     * @throws [IllegalArgumentException] when:
+     * @throws [InvalidParameterException] when:
      *  - [algorithm] is blank
      * */
-    @Throws(IllegalArgumentException::class)
+    @Throws(InvalidParameterException::class)
     protected constructor(algorithm: String, engine: Engine)
 
     /**

--- a/library/mac/src/commonMain/kotlin/org/kotlincrypto/core/mac/internal/-CommonPlatform.kt
+++ b/library/mac/src/commonMain/kotlin/org/kotlincrypto/core/mac/internal/-CommonPlatform.kt
@@ -64,10 +64,10 @@ internal inline fun Mac.commonClearKey(engineReset: (ByteArray) -> Unit) {
 
     try {
         engineReset(SINGLE_0BYTE_KEY)
-    } catch (e1: IllegalArgumentException) {
+    } catch (e1: Throwable) {
         try {
             engineReset(ByteArray(macLength()))
-        } catch (e2: IllegalArgumentException) {
+        } catch (e2: Throwable) {
             e2.addSuppressed(e1)
             throw e2
         }

--- a/library/mac/src/commonMain/kotlin/org/kotlincrypto/core/mac/internal/-CommonPlatform.kt
+++ b/library/mac/src/commonMain/kotlin/org/kotlincrypto/core/mac/internal/-CommonPlatform.kt
@@ -18,7 +18,9 @@
 package org.kotlincrypto.core.mac.internal
 
 import org.kotlincrypto.core.mac.Mac
+import org.kotlincrypto.error.InvalidParameterException
 import org.kotlincrypto.error.ShortBufferException
+import org.kotlincrypto.error.requireParam
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
@@ -26,9 +28,9 @@ import kotlin.contracts.contract
 private val SINGLE_0BYTE_KEY = ByteArray(1) { 0 }
 
 @Suppress("UnusedReceiverParameter")
-@Throws(IllegalArgumentException::class)
+@Throws(InvalidParameterException::class)
 internal inline fun Mac.commonInit(algorithm: String) {
-    require(algorithm.isNotBlank()) { "algorithm cannot be blank" }
+    requireParam(algorithm.isNotBlank()) { "algorithm cannot be blank" }
 }
 
 internal inline fun Mac.commonToString(): String {

--- a/library/mac/src/commonTest/kotlin/org/kotlincrypto/core/mac/MacUnitTest.kt
+++ b/library/mac/src/commonTest/kotlin/org/kotlincrypto/core/mac/MacUnitTest.kt
@@ -15,6 +15,7 @@
  **/
 package org.kotlincrypto.core.mac
 
+import org.kotlincrypto.error.InvalidKeyException
 import org.kotlincrypto.error.InvalidParameterException
 import org.kotlincrypto.error.ShortBufferException
 import kotlin.test.*
@@ -23,7 +24,7 @@ class MacUnitTest {
 
     @Test
     fun givenMac_whenEmptyKey_thenThrowsException() {
-        assertFailsWith<IllegalArgumentException> {
+        assertFailsWith<InvalidKeyException> {
             TestMac(ByteArray(0), "not empty")
         }
     }
@@ -38,7 +39,7 @@ class MacUnitTest {
     @Test
     fun givenMac_whenResetWithEmptyKey_thenThrowsException() {
         val mac = TestMac(ByteArray(5), "my algorithm")
-        assertFailsWith<IllegalArgumentException> {
+        assertFailsWith<InvalidKeyException> {
             mac.reset(ByteArray(0))
         }
     }

--- a/library/mac/src/commonTest/kotlin/org/kotlincrypto/core/mac/MacUnitTest.kt
+++ b/library/mac/src/commonTest/kotlin/org/kotlincrypto/core/mac/MacUnitTest.kt
@@ -15,6 +15,7 @@
  **/
 package org.kotlincrypto.core.mac
 
+import org.kotlincrypto.error.InvalidParameterException
 import org.kotlincrypto.error.ShortBufferException
 import kotlin.test.*
 
@@ -29,7 +30,7 @@ class MacUnitTest {
 
     @Test
     fun givenMac_whenBlankAlgorithm_thenThrowsException() {
-        assertFailsWith<IllegalArgumentException> {
+        assertFailsWith<InvalidParameterException> {
             TestMac(ByteArray(5), "  ")
         }
     }

--- a/library/mac/src/jvmMain/kotlin/org/kotlincrypto/core/mac/Mac.kt
+++ b/library/mac/src/jvmMain/kotlin/org/kotlincrypto/core/mac/Mac.kt
@@ -20,6 +20,7 @@ package org.kotlincrypto.core.mac
 import org.kotlincrypto.core.*
 import org.kotlincrypto.core.mac.internal.*
 import org.kotlincrypto.error.InvalidKeyException
+import org.kotlincrypto.error.InvalidParameterException
 import org.kotlincrypto.error.ShortBufferException
 import java.nio.ByteBuffer
 import java.security.Key
@@ -55,10 +56,10 @@ public actual abstract class Mac: javax.crypto.Mac, Algorithm, Copyable<Mac>, Re
      *
      * @param [algorithm] See [Algorithm.algorithm]
      * @param [engine] See [Engine]
-     * @throws [IllegalArgumentException] when:
+     * @throws [InvalidParameterException] when:
      *  - [algorithm] is blank
      * */
-    @Throws(IllegalArgumentException::class)
+    @Throws(InvalidParameterException::class)
     protected actual constructor(algorithm: String, engine: Engine): super(
         /* macSpi    */ engine,
         /* provider  */ AndroidApi21to23MacSpiProvider.createOrNull(engine, algorithm),

--- a/library/mac/src/jvmMain/kotlin/org/kotlincrypto/core/mac/Mac.kt
+++ b/library/mac/src/jvmMain/kotlin/org/kotlincrypto/core/mac/Mac.kt
@@ -45,7 +45,6 @@ import javax.crypto.SecretKey
  * https://docs.oracle.com/en/java/javase/11/docs/specs/security/standard-names.html#mac-algorithms
  *
  * @see [Engine]
- * @throws [IllegalArgumentException] if [algorithm] is blank
  * */
 public actual abstract class Mac: javax.crypto.Mac, Algorithm, Copyable<Mac>, Resettable, Updatable {
 
@@ -68,9 +67,8 @@ public actual abstract class Mac: javax.crypto.Mac, Algorithm, Copyable<Mac>, Re
         commonInit(algorithm)
         this.engine = engine
 
-        // Engine.engineInit is overridden as no-op, so this does
-        // nothing other than set `javax.crypto.Mac.initialized`
-        // to true
+        // Engine.engineInit is overridden to ignore EmptyKey, so this does
+        // nothing other than set `javax.crypto.Mac.initialized` to true.
         super.init(EmptyKey)
     }
 
@@ -130,12 +128,16 @@ public actual abstract class Mac: javax.crypto.Mac, Algorithm, Copyable<Mac>, Re
      * This is useful if wanting to zero out the key before de-referencing.
      *
      * @see [clearKey]
-     * @throws [IllegalArgumentException] if [newKey] is empty, or of a length
+     * @throws [InvalidKeyException] if [newKey] is empty, or of a length
      *   inappropriate for the [Mac] implementation.
      * */
     public actual fun reset(newKey: ByteArray) {
-        require(newKey.isNotEmpty()) { "newKey cannot be empty" }
-        engine.reset(newKey)
+        if (newKey.isEmpty()) throw InvalidKeyException("newKey cannot be empty")
+        try {
+            engine.reset(newKey)
+        } catch (e: IllegalArgumentException) {
+            throw InvalidKeyException(e)
+        }
     }
 
     /**
@@ -173,9 +175,9 @@ public actual abstract class Mac: javax.crypto.Mac, Algorithm, Copyable<Mac>, Re
          * or [Engine.doFinalInto] have been invoked).
          *
          * @param [key] The key that this [Engine] instance will use to apply its function to
-         * @throws [IllegalArgumentException] if [key] is empty
+         * @throws [InvalidKeyException] if [key] is empty
          * */
-        @Throws(IllegalArgumentException::class)
+        @Throws(InvalidKeyException::class)
         public actual constructor(key: ByteArray): this(key, resetOnDoFinal = true)
 
         /**
@@ -183,11 +185,11 @@ public actual abstract class Mac: javax.crypto.Mac, Algorithm, Copyable<Mac>, Re
          *
          * @param [key] the key that this [Engine] instance will use to apply its function to
          * @param [resetOnDoFinal] See [Engine.resetOnDoFinal] documentation
-         * @throws [IllegalArgumentException] if [key] is empty
+         * @throws [InvalidKeyException] if [key] is empty
          * */
-        @Throws(IllegalArgumentException::class)
+        @Throws(InvalidKeyException::class)
         public actual constructor(key: ByteArray, resetOnDoFinal: Boolean) {
-            require(key.isNotEmpty()) { "key cannot be empty" }
+            if (key.isEmpty()) throw InvalidKeyException("key cannot be empty")
             this.resetOnDoFinal = resetOnDoFinal
         }
 
@@ -240,10 +242,10 @@ public actual abstract class Mac: javax.crypto.Mac, Algorithm, Copyable<Mac>, Re
          * before passing it here. Implementations should ensure any old key material
          * is zeroed out.
          *
-         * @throws [IllegalArgumentException] if [newKey] is a length inappropriate
-         *   for the [Mac] implementation.
+         * @throws [InvalidKeyException] if [newKey] is a length inappropriate
+         *   for the [Engine] implementation.
          * */
-        @Throws(IllegalArgumentException::class)
+        @Throws(InvalidKeyException::class)
         public actual abstract fun reset(newKey: ByteArray)
 
         // Gets set in engineDoFinal if resetOnDoFinal is set to false. Subsequent

--- a/library/mac/src/nonJvmMain/kotlin/org/kotlincrypto/core/mac/Mac.kt
+++ b/library/mac/src/nonJvmMain/kotlin/org/kotlincrypto/core/mac/Mac.kt
@@ -19,6 +19,7 @@ package org.kotlincrypto.core.mac
 
 import org.kotlincrypto.core.*
 import org.kotlincrypto.core.mac.internal.*
+import org.kotlincrypto.error.InvalidKeyException
 import org.kotlincrypto.error.InvalidParameterException
 import org.kotlincrypto.error.ShortBufferException
 
@@ -37,7 +38,6 @@ import org.kotlincrypto.error.ShortBufferException
  * https://docs.oracle.com/en/java/javase/11/docs/specs/security/standard-names.html#mac-algorithms
  *
  * @see [Engine]
- * @throws [IllegalArgumentException] if [algorithm] is blank
  * */
 public actual abstract class Mac: Algorithm, Copyable<Mac>, Resettable, Updatable {
 
@@ -152,12 +152,16 @@ public actual abstract class Mac: Algorithm, Copyable<Mac>, Resettable, Updatabl
      * This is useful if wanting to zero out the key before de-referencing.
      *
      * @see [clearKey]
-     * @throws [IllegalArgumentException] if [newKey] is empty, or of a length
+     * @throws [InvalidKeyException] if [newKey] is empty, or of a length
      *   inappropriate for the [Mac] implementation.
      * */
     public actual fun reset(newKey: ByteArray) {
-        require(newKey.isNotEmpty()) { "newKey cannot be empty" }
-        engine.reset(newKey)
+        if (newKey.isEmpty()) throw InvalidKeyException("newKey cannot be empty")
+        try {
+            engine.reset(newKey)
+        } catch (e: IllegalArgumentException) {
+            throw InvalidKeyException(e)
+        }
     }
 
     /**
@@ -193,9 +197,9 @@ public actual abstract class Mac: Algorithm, Copyable<Mac>, Resettable, Updatabl
          * or [Engine.doFinalInto] have been invoked).
          *
          * @param [key] The key that this [Engine] instance will use to apply its function to
-         * @throws [IllegalArgumentException] if [key] is empty
+         * @throws [InvalidKeyException] if [key] is empty
          * */
-        @Throws(IllegalArgumentException::class)
+        @Throws(InvalidKeyException::class)
         public actual constructor(key: ByteArray): this(key, resetOnDoFinal = true)
 
         /**
@@ -203,11 +207,11 @@ public actual abstract class Mac: Algorithm, Copyable<Mac>, Resettable, Updatabl
          *
          * @param [key] the key that this [Engine] instance will use to apply its function to
          * @param [resetOnDoFinal] See [Engine.resetOnDoFinal] documentation
-         * @throws [IllegalArgumentException] if [key] is empty
+         * @throws [InvalidKeyException] if [key] is empty
          * */
-        @Throws(IllegalArgumentException::class)
+        @Throws(InvalidKeyException::class)
         public actual constructor(key: ByteArray, resetOnDoFinal: Boolean) {
-            require(key.isNotEmpty()) { "key cannot be empty" }
+            if (key.isEmpty()) throw InvalidKeyException("key cannot be empty")
             this.resetOnDoFinal = resetOnDoFinal
         }
 
@@ -260,10 +264,10 @@ public actual abstract class Mac: Algorithm, Copyable<Mac>, Resettable, Updatabl
          * before passing it here. Implementations should ensure any old key material
          * is zeroed out.
          *
-         * @throws [IllegalArgumentException] if [newKey] is a length inappropriate
-         *   for the [Mac] implementation.
+         * @throws [InvalidKeyException] if [newKey] is a length inappropriate
+         *   for the [Engine] implementation.
          * */
-        @Throws(IllegalArgumentException::class)
+        @Throws(InvalidKeyException::class)
         public actual abstract fun reset(newKey: ByteArray)
 
         private val code = Any()

--- a/library/mac/src/nonJvmMain/kotlin/org/kotlincrypto/core/mac/Mac.kt
+++ b/library/mac/src/nonJvmMain/kotlin/org/kotlincrypto/core/mac/Mac.kt
@@ -19,6 +19,7 @@ package org.kotlincrypto.core.mac
 
 import org.kotlincrypto.core.*
 import org.kotlincrypto.core.mac.internal.*
+import org.kotlincrypto.error.InvalidParameterException
 import org.kotlincrypto.error.ShortBufferException
 
 /**
@@ -48,10 +49,10 @@ public actual abstract class Mac: Algorithm, Copyable<Mac>, Resettable, Updatabl
      *
      * @param [algorithm] See [Algorithm.algorithm]
      * @param [engine] See [Engine]
-     * @throws [IllegalArgumentException] when:
+     * @throws [InvalidParameterException] when:
      *  - [algorithm] is blank
      * */
-    @Throws(IllegalArgumentException::class)
+    @Throws(InvalidParameterException::class)
     protected actual constructor(algorithm: String, engine: Engine) {
         commonInit(algorithm)
         this.algorithm = algorithm

--- a/library/xof/src/commonMain/kotlin/org/kotlincrypto/core/xof/Xof.kt
+++ b/library/xof/src/commonMain/kotlin/org/kotlincrypto/core/xof/Xof.kt
@@ -18,6 +18,7 @@
 package org.kotlincrypto.core.xof
 
 import org.kotlincrypto.core.*
+import org.kotlincrypto.error.InvalidKeyException
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
@@ -67,7 +68,7 @@ public sealed class Xof<A: XofAlgorithm>(
          * Helper to provide access to the instance backing [Xof], if said instance
          * can be re-keyed (such as a [org.kotlincrypto.core.mac.Mac]).
          *
-         * @throws [IllegalArgumentException] if [newKey] is unacceptable.
+         * @throws [InvalidKeyException] if [newKey] is unacceptable.
          * */
         @JvmStatic
         public fun <A: ReKeyableXofAlgorithm> Xof<A>.reset(newKey: ByteArray) { delegate.reset(newKey) }

--- a/library/xof/src/commonMain/kotlin/org/kotlincrypto/core/xof/XofAlgorithm.kt
+++ b/library/xof/src/commonMain/kotlin/org/kotlincrypto/core/xof/XofAlgorithm.kt
@@ -16,6 +16,7 @@
 package org.kotlincrypto.core.xof
 
 import org.kotlincrypto.core.Algorithm
+import org.kotlincrypto.error.InvalidKeyException
 
 /**
  * Denotes a class as a user of a specified cryptographic [algorithm]
@@ -37,7 +38,7 @@ public interface ReKeyableXofAlgorithm: XofAlgorithm {
      *
      * This is useful if wanting to clear the key before de-referencing.
      *
-     * @throws [IllegalArgumentException] if [newKey] is unacceptable.
+     * @throws [InvalidKeyException] if [newKey] is unacceptable.
      * */
     public fun reset(newKey: ByteArray)
 }


### PR DESCRIPTION
Closes #112 

`Digest` and `Mac` constructors now throw `InvalidParameterException` instead of `IllegalArgumentException`

`Mac.Engine` constructors and `Mac.reset(newKey)` now throw `InvalidKeyException` instead of `IllegalArgumentException`.